### PR TITLE
Changes to avoid iterator next() calls.

### DIFF
--- a/drv/AbstractCollection.drv
+++ b/drv/AbstractCollection.drv
@@ -18,6 +18,7 @@
 package PACKAGE;
 
 import java.util.AbstractCollection;
+import java.util.Collection;
 
 /** An abstract class providing basic methods for collections implementing a type-specific interface.
  *
@@ -159,6 +160,42 @@ public abstract class ABSTRACT_COLLECTION KEY_GENERIC extends AbstractCollection
 				retVal = true;
 			}
 		return retVal;
+	}
+
+	@Override
+	public boolean addAll(final Collection<? extends KEY_GENERIC_CLASS> c) {
+		if (c instanceof COLLECTION){
+			return addAll((COLLECTION) c);
+		} else {
+			return super.addAll(c);
+		}
+	}
+
+	@Override
+	public boolean containsAll(final Collection<?> c) {
+		if (c instanceof COLLECTION) {
+			return containsAll((COLLECTION) c);
+		} else {
+			return super.containsAll(c);
+		}
+	}
+
+	@Override
+	public boolean removeAll(final Collection<?> c) {
+		if (c instanceof COLLECTION) {
+			return removeAll((COLLECTION) c);
+		} else {
+			return super.removeAll(c);
+		}
+	}
+
+	@Override
+	public boolean retainAll(final Collection<?> c) {
+		if (c instanceof COLLECTION) {
+			return retainAll((COLLECTION) c);
+		} else {
+			return super.retainAll(c);
+		}
 	}
 #endif
 

--- a/drv/Collections.drv
+++ b/drv/Collections.drv
@@ -17,6 +17,7 @@
 
 package PACKAGE;
 
+import java.util.Arrays;
 import java.util.Collection;
 
 import it.unimi.dsi.fastutil.objects.ObjectArrays;
@@ -370,6 +371,40 @@ public final class COLLECTIONS {
 		public KEY_ITERATOR KEY_GENERIC iterator() { return iterable.iterator(); }
 	}
 
+
+#if KEYS_PRIMITIVE && defined JDK_PRIMITIVE_ITERATOR
+	/**
+	 * Sorts the specified list in ascending order.
+	 *
+	 * @param l the list object to sort.
+	 */
+    public static void sort(LIST l) {
+        KEY_TYPE[] arr = l.TO_KEY_ARRAY();
+        Arrays.sort(arr);
+        KEY_LIST_ITERATOR itr = l.listIterator();
+        for (KEY_TYPE e : arr) {
+            itr.NEXT_KEY();
+            itr.set(e);
+        }
+    }
+
+	/**
+	 * Returns the minimum element in given collection. The given collection must be non-empty.
+	 *
+	 * @param c the collection to return minimum element for.
+	 */
+    public static KEY_TYPE min(COLLECTION c) {
+        KEY_ITERATOR itr = c.iterator();
+        KEY_TYPE candidate = itr.NEXT_KEY();
+        while (itr.hasNext()) {
+            KEY_TYPE e = itr.NEXT_KEY();
+            if (e < candidate) {
+                candidate = e;
+            }
+        }
+        return candidate;
+    }
+#endif
 
 	/** Returns an unmodifiable collection backed by the specified iterable.
 	 *

--- a/drv/ImmutableList.drv
+++ b/drv/ImmutableList.drv
@@ -52,7 +52,17 @@ public abstract class IMMUTABLE_LIST extends ABSTRACT_LIST {
             case 0:
                 return of();
             case 1:
-                return new SingletonImmutableList(collection.iterator().next());
+#if KEYS_PRIMITIVE
+                KEY_TYPE singleValue;
+                if (collection instanceof ABSTRACT_COLLECTION) {
+                    singleValue = ((ABSTRACT_COLLECTION) collection).iterator().NEXT_KEY();
+                } else {
+                    singleValue = collection.iterator().next();
+                }
+#else
+                KEY_TYPE singleValue = collection.iterator().next();
+#endif
+                return new SingletonImmutableList(singleValue);
             default:
                 return new RegularImmutableList(collection);
         }
@@ -94,6 +104,16 @@ public abstract class IMMUTABLE_LIST extends ABSTRACT_LIST {
 
         private RegularImmutableList(Collection<KEY_GENERIC_CLASS> collection) {
             data = new KEY_TYPE[collection.size()];
+#if KEYS_PRIMITIVE
+            if (collection instanceof ABSTRACT_COLLECTION) {
+                KEY_ITERATOR iterator = ((ABSTRACT_COLLECTION) collection).iterator();
+                int pos = 0;
+                while (iterator.hasNext()) {
+                    data[pos++] = iterator.NEXT_KEY();
+                }
+                return;
+            }
+#endif
             Iterator<KEY_GENERIC_CLASS> iterator = collection.iterator();
             int pos = 0;
             while (iterator.hasNext()) {


### PR DESCRIPTION
Changes AbstractCollection and ImmutableList to avoid next() calls for
iterators whenever possible.

Also adds some utilities to Collections so clients don't have to use
java util collections methods that use iterative next() calls.