### PR TITLE
Add assertion error for next() calls

### DIFF
--- a/drv/Iterator.drv
+++ b/drv/Iterator.drv
@@ -58,6 +58,7 @@ public interface KEY_ITERATOR KEY_GENERIC extends Iterator<KEY_GENERIC_CLASS> {
 	@Deprecated
 	@Override
 	default KEY_CLASS next() {
+		if (ASSERTS_VALUE) assert false : "Use primitive next..() method instead.";
 		return KEY_CLASS.valueOf(NEXT_KEY());
 	}
 

--- a/drv/Iterators.drv
+++ b/drv/Iterators.drv
@@ -877,7 +877,10 @@ public final class ITERATORS {
 
 		@Deprecated
 		@Override
-		public KEY_GENERIC_CLASS next() { return KEY_GENERIC_CLASS.valueOf(iterator.nextByte()); }
+		public KEY_GENERIC_CLASS next() {
+			if (ASSERTS_VALUE) assert false : "Use the primitive next..() method instead.";
+			return KEY_GENERIC_CLASS.valueOf(iterator.nextByte());
+		}
 
 		@Override
 		public KEY_TYPE NEXT_KEY() { return iterator.nextByte(); }
@@ -914,7 +917,10 @@ public final class ITERATORS {
 
 		@Deprecated
 		@Override
-		public KEY_GENERIC_CLASS next() { return KEY_GENERIC_CLASS.valueOf(iterator.nextShort()); }
+		public KEY_GENERIC_CLASS next() {
+			if (ASSERTS_VALUE) assert false : "Use the primitive next..() method instead.";
+			return KEY_GENERIC_CLASS.valueOf(iterator.nextShort());
+		}
 
 		@Override
 		public KEY_TYPE NEXT_KEY() { return iterator.nextShort(); }
@@ -952,7 +958,10 @@ public final class ITERATORS {
 
 		@Deprecated
 		@Override
-		public KEY_GENERIC_CLASS next() { return KEY_GENERIC_CLASS.valueOf(iterator.nextInt()); }
+		public KEY_GENERIC_CLASS next() {
+			if (ASSERTS_VALUE) assert false : "Use the primitive next..() method instead.";
+			return KEY_GENERIC_CLASS.valueOf(iterator.nextInt());
+		}
 
 		@Override
 		public KEY_TYPE NEXT_KEY() { return iterator.nextInt(); }
@@ -991,7 +1000,10 @@ public final class ITERATORS {
 
 		@Deprecated
 		@Override
-		public KEY_GENERIC_CLASS next() { return KEY_GENERIC_CLASS.valueOf(iterator.nextFloat()); }
+		public KEY_GENERIC_CLASS next() {
+			if (ASSERTS_VALUE) assert false : "Use the primitive next..() method instead.";
+			return KEY_GENERIC_CLASS.valueOf(iterator.nextFloat());
+		}
 
 		@Override
 		public KEY_TYPE NEXT_KEY() { return iterator.nextFloat(); }

--- a/drv/OpenHashBigSet.drv
+++ b/drv/OpenHashBigSet.drv
@@ -810,9 +810,11 @@ public class OPEN_HASH_BIG_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC impl
 				throw new AssertionError("Hash table has key " + BIG_ARRAYS.get(key, n) + " marked as occupied, but the key does not belong to the table");
 
 #if KEYS_PRIMITIVE
-		java.util.HashSet<KEY_GENERIC_CLASS> s = new java.util.HashSet<KEY_GENERIC_CLASS> ();
+		java.util.Set<KEY_GENERIC_CLASS> s = new java.util.HashSet<KEY_GENERIC_CLASS> ();
+#elif KEY_CLASS_Object
+		java.util.Set<Object> s = new java.util.HashSet<Object>();
 #else
-		java.util.HashSet<Object> s = new java.util.HashSet<Object>();
+		java.util.Set<Object> s = java.util.Collections.newSetFromMap(new java.util.IdentityHashMap<Object, Boolean>());
 #endif
 
 		for(long i = size(); i-- != 0;)

--- a/drv/OpenHashSet.drv
+++ b/drv/OpenHashSet.drv
@@ -1715,9 +1715,11 @@ public class OPEN_HASH_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC implemen
 				throw new AssertionError("Hash table has key " + key[n] + " marked as occupied, but the key does not belong to the table");
 
 #if KEYS_PRIMITIVE
-		java.util.HashSet<KEY_GENERIC_CLASS> s = new java.util.HashSet<KEY_GENERIC_CLASS> ();
+		java.util.Set<KEY_GENERIC_CLASS> s = new java.util.HashSet<KEY_GENERIC_CLASS> ();
+#elif KEY_CLASS_Object
+		java.util.Set<Object> s = new java.util.HashSet<Object>();
 #else
-		java.util.HashSet<Object> s = new java.util.HashSet<Object>();
+		java.util.Set<Object> s = java.util.Collections.newSetFromMap(new java.util.IdentityHashMap<Object, Boolean>());
 #endif
 
 		for(int i = key.length - 1; i-- != 0;)


### PR DESCRIPTION
Calling Iterator's next() method will fail if assertions are enabled.

Note, that we can't guard the new code by fastutils'
if (ASSERTS_VALUE) assert ...
since that requires enabling all assertions in fastutil.
Currently, fwd code base fails a assert in referenceopenhashset,
though that's not really an error.