### PR TITLE
Immutable support changes:

### DIFF
--- a/drv/Collection.drv
+++ b/drv/Collection.drv
@@ -19,6 +19,18 @@ package PACKAGE;
 
 import java.util.Collection;
 
+#ifdef JDK_PRIMITIVE_STREAM;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.JDK_PRIMITIVE_STREAM;
+import java.util.stream.StreamSupport;
+
+#if KEY_WIDENED
+import WIDENED_KEY_PACKAGE.WIDENED_KEY_ITERATORS;
+#endif
+
+#endif
+
 /** A type-specific {@link Collection}; provides some additional methods
  * that use polymorphism to avoid (un)boxing.
  *
@@ -192,4 +204,13 @@ public interface COLLECTION KEY_GENERIC extends Collection<KEY_GENERIC_CLASS>, K
 
 #endif
 
+#ifdef JDK_PRIMITIVE_STREAM
+	default JDK_PRIMITIVE_STREAM JDK_PRIMITIVE_STREAM_METHOD() {
+#if KEY_WIDENED
+		return StreamSupport.JDK_PRIMITIVE_STREAM_METHOD(Spliterators.spliterator(WIDENED_KEY_ITERATORS.wrap(iterator()), size(), Spliterator.NONNULL), false);
+#else
+		return StreamSupport.JDK_PRIMITIVE_STREAM_METHOD(Spliterators.spliterator(iterator(), size(), Spliterator.NONNULL), false);
+#endif
+	}
+#endif
 }

--- a/drv/Collectors.drv
+++ b/drv/Collectors.drv
@@ -1,48 +1,137 @@
 package PACKAGE;
 
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
 import java.util.stream.Collector;
+
+#ifdef JDK_PRIMITIVE_STREAM
+import java.util.function.JDK_PRIMITIVE_OBJKEY_CONSUMER;
+import java.util.stream.JDK_PRIMITIVE_STREAM;
+#endif
 
 public final class COLLECTORS {
 
     private COLLECTORS() { }
 
-    public static Collector<KEY_GENERIC_CLASS, ARRAY_LIST, LIST> toList() {
+#ifdef JDK_PRIMITIVE_STREAM
+    public static final Supplier<ARRAY_LIST> LIST_SUPP = ARRAY_LIST::new;
+    public static final JDK_PRIMITIVE_OBJKEY_CONSUMER<ARRAY_LIST> LIST_ACC = (l, e) -> l.add((KEY_TYPE) e);
+    public static final BiConsumer<ARRAY_LIST, ARRAY_LIST> LIST_COMB = ARRAY_LIST::addAll;
+
+    public static final Supplier<OPEN_HASH_SET> SET_SUPP = OPEN_HASH_SET::new;
+    public static final JDK_PRIMITIVE_OBJKEY_CONSUMER<OPEN_HASH_SET> SET_ACC = (s, e) -> s.add((KEY_TYPE) e);
+    public static final BiConsumer<OPEN_HASH_SET, OPEN_HASH_SET> SET_COMB = OPEN_HASH_SET::addAll;
+#endif
+
+#if KEYS_PRIMITIVE
+
+    /**
+     * Should be used when working with boxed objects. This method can be slower if original stream wasn't
+     * using boxed objects.
+     */
+    public static Collector<KEY_GENERIC_CLASS, ARRAY_LIST, LIST> toListSlow() {
         return Collector.of(
-            ARRAY_LIST::new,
-            ARRAY_LIST::add,
-            (b1, b2) -> {
-                b1.addAll(b2);
-                return b1;
-            },
-            s -> s);
+                ARRAY_LIST::new,
+                (l, e) -> l.add((KEY_TYPE) e),
+                (b1, b2) -> {
+                    b1.addAll(b2);
+                    return b1;
+                },
+                s -> s);
     }
 
-    public static Collector<KEY_GENERIC_CLASS, OPEN_HASH_SET, SET> toSet() {
+    /**
+     * Should be used when working with boxed objects. This method can be slower if original stream wasn't
+     * using boxed objects.
+     */
+    public static Collector<KEY_GENERIC_CLASS, IMMUTABLE_LIST.Builder, IMMUTABLE_LIST> toImmutableListSlow() {
         return Collector.of(
-            OPEN_HASH_SET::new,
-            OPEN_HASH_SET::add,
-            (b1, b2) -> {
-                b1.addAll(b2);
-                return b1;
-            },
-            s -> s);
+                IMMUTABLE_LIST::builder,
+                IMMUTABLE_LIST.Builder::add,
+                IMMUTABLE_LIST.Builder::combine,
+                IMMUTABLE_LIST.Builder::build);
+    }
+#endif
+
+#ifdef JDK_PRIMITIVE_STREAM
+    public static ARRAY_LIST toList(JDK_PRIMITIVE_STREAM stream) {
+        return stream.collect(LIST_SUPP, LIST_ACC, LIST_COMB);
     }
 
-    public static Collector<KEY_GENERIC_CLASS, IMMUTABLE_LIST.Builder, IMMUTABLE_LIST> toImmutableList() {
+    public static IMMUTABLE_LIST toImmutableList(JDK_PRIMITIVE_STREAM stream) {
+        return IMMUTABLE_LIST.copyOf(toList(stream));
+    }
+#elif !KEYS_PRIMITIVE
+    public static KEY_GENERIC Collector<KEY_GENERIC_CLASS, ARRAY_LIST, LIST> toList() {
         return Collector.of(
-            IMMUTABLE_LIST::builder,
-            IMMUTABLE_LIST.Builder::add,
-            IMMUTABLE_LIST.Builder::combine,
-            IMMUTABLE_LIST.Builder::build);
+                ARRAY_LIST::new,
+                (l, e) -> l.add((KEY_TYPE) e),
+                (b1, b2) -> {
+                    b1.addAll(b2);
+                    return b1;
+                },
+                s -> s);
+    }
+#endif
+
+#if KEYS_PRIMITIVE
+    /**
+     * Should be used when working with boxed objects. This method can be slower if original stream wasn't
+     * using boxed objects.
+     */
+    public static Collector<KEY_GENERIC_CLASS, OPEN_HASH_SET, SET> toSetSlow() {
+        return Collector.of(
+                OPEN_HASH_SET::new,
+                (s, e) -> s.add((KEY_TYPE) e),
+                (b1, b2) -> {
+                    b1.addAll(b2);
+                    return b1;
+                },
+                s -> s);
     }
 
-    public static Collector<KEY_GENERIC_CLASS, IMMUTABLE_SET.Builder, IMMUTABLE_SET> toImmutableSet() {
+    /**
+     * Should be used when working with boxed objects. This method can be slower if original stream wasn't
+     * using boxed objects.
+     */
+    public static Collector<KEY_GENERIC_CLASS, IMMUTABLE_SET.Builder, IMMUTABLE_SET> toImmutableSetSlow() {
         return Collector.of(
-            IMMUTABLE_SET::builder,
-            IMMUTABLE_SET.Builder::add,
-            IMMUTABLE_SET.Builder::combine,
-            IMMUTABLE_SET.Builder::build);
+                IMMUTABLE_SET::builder,
+                IMMUTABLE_SET.Builder::add,
+                IMMUTABLE_SET.Builder::combine,
+                IMMUTABLE_SET.Builder::build);
     }
+#endif
+
+#ifdef JDK_PRIMITIVE_STREAM
+    public static OPEN_HASH_SET toSet(JDK_PRIMITIVE_STREAM stream) {
+        return stream.collect(SET_SUPP, SET_ACC, SET_COMB);
+    }
+
+    public static IMMUTABLE_SET toImmutableSet(JDK_PRIMITIVE_STREAM stream) {
+        // More efficient to collect to list before doing an immutable set copy of.
+        return IMMUTABLE_SET.copyOf(toList(stream));
+    }
+#elif !KEYS_PRIMITIVE
+    public static KEY_GENERIC Collector<KEY_GENERIC_CLASS, OPEN_HASH_SET, SET> toSet() {
+        return Collector.of(
+                OPEN_HASH_SET::new,
+                (s, e) -> s.add((KEY_TYPE) e),
+                (b1, b2) -> {
+                    b1.addAll(b2);
+                    return b1;
+                },
+                s -> s);
+    }
+
+    public static KEY_GENERIC Collector<KEY_GENERIC_CLASS, IMMUTABLE_SET.Builder, IMMUTABLE_SET> toImmutableSet() {
+        return Collector.of(
+                IMMUTABLE_SET::builder,
+                IMMUTABLE_SET.Builder::add,
+                IMMUTABLE_SET.Builder::combine,
+                IMMUTABLE_SET.Builder::build);
+    }
+#endif
 
 }
 

--- a/drv/ImmutableList.drv
+++ b/drv/ImmutableList.drv
@@ -21,6 +21,16 @@ import java.util.NoSuchElementException;
 import java.util.Spliterator;
 import java.util.Spliterators;
 
+#ifdef JDK_PRIMITIVE_STREAM
+import java.util.stream.JDK_PRIMITIVE_STREAM;
+import java.util.stream.StreamSupport;
+
+#if KEY_WIDENED
+import WIDENED_KEY_PACKAGE.WIDENED_KEY_ITERATORS;
+#endif
+
+#endif
+
 /**
  * A type-specific immutable {@link java.util.List}. It provides some
  * additional methods compared to {@link java.util.List} that use
@@ -87,9 +97,20 @@ public abstract class IMMUTABLE_LIST extends ABSTRACT_LIST {
         return new ImmutableSubList(this, from, to);
     }
 
-#ifdef JDK_PRIMITIVE_SPLITERATOR
+#if defined JDK_PRIMITIVE_SPLITERATOR && !KEY_WIDENED
     @Override
     public abstract JDK_PRIMITIVE_SPLITERATOR spliterator();
+#endif
+
+#ifdef JDK_PRIMITIVE_STREAM
+    @Override
+    public JDK_PRIMITIVE_STREAM JDK_PRIMITIVE_STREAM_METHOD() {
+#if KEY_WIDENED
+        return StreamSupport.JDK_PRIMITIVE_STREAM_METHOD(Spliterators.spliterator(WIDENED_KEY_ITERATORS.wrap(iterator()), size(), Spliterator.IMMUTABLE | Spliterator.NONNULL | Spliterator.ORDERED), false);
+#else
+        return StreamSupport.JDK_PRIMITIVE_STREAM_METHOD(spliterator(), false);
+#endif
+    }
 #endif
 
     /** Implementation of this immutable list used for 0 or 2+ elements (not 1). */
@@ -131,7 +152,7 @@ public abstract class IMMUTABLE_LIST extends ABSTRACT_LIST {
             return data.length;
         }
 
-#ifdef JDK_PRIMITIVE_SPLITERATOR
+#if defined JDK_PRIMITIVE_SPLITERATOR && !KEY_WIDENED
         @Override
         public JDK_PRIMITIVE_SPLITERATOR spliterator() {
             return Spliterators.spliterator(data, Spliterator.IMMUTABLE | Spliterator.NONNULL | Spliterator.ORDERED);
@@ -160,7 +181,7 @@ public abstract class IMMUTABLE_LIST extends ABSTRACT_LIST {
             return 1;
         }
 
-#ifdef JDK_PRIMITIVE_SPLITERATOR
+#if defined JDK_PRIMITIVE_SPLITERATOR && !KEY_WIDENED
 		@Override
         public JDK_PRIMITIVE_SPLITERATOR spliterator() {
             return IMMUTABLES.singletonSpliterator(element);
@@ -311,13 +332,12 @@ public abstract class IMMUTABLE_LIST extends ABSTRACT_LIST {
             };
         }
 
-#ifdef JDK_PRIMITIVE_SPLITERATOR
+#if defined JDK_PRIMITIVE_SPLITERATOR && !KEY_WIDENED
         @Override
         public JDK_PRIMITIVE_SPLITERATOR spliterator() {
             return Spliterators.spliterator(iterator(), size(), Spliterator.IMMUTABLE | Spliterator.NONNULL | Spliterator.ORDERED);
         }
 #endif
-
     }
 }
 

--- a/drv/ImmutableMap.drv
+++ b/drv/ImmutableMap.drv
@@ -16,7 +16,7 @@ package PACKAGE;
 
 import it.unimi.dsi.fastutil.Hash;
 import it.unimi.dsi.fastutil.HashCommon;
-import it.unimi.dsi.fastutil.objects.AbstractObjectSet;
+import it.unimi.dsi.fastutil.objects.ImmutableObjectSet;
 import it.unimi.dsi.fastutil.objects.ObjectIterator;
 import it.unimi.dsi.fastutil.objects.ObjectIterators;
 
@@ -136,7 +136,7 @@ public abstract class IMMUTABLE_MAP KEY_VALUE_GENERIC implements MAP KEY_VALUE_G
 
     /** Returns a new Builder. */
     public static KEY_VALUE_GENERIC Builder KEY_VALUE_GENERIC builder() {
-        return new Builder KEY_VALUE_GENERIC_DIAMOND ();
+        return new Builder KEY_VALUE_GENERIC_DIAMOND();
     }
 
     /**
@@ -145,7 +145,7 @@ public abstract class IMMUTABLE_MAP KEY_VALUE_GENERIC implements MAP KEY_VALUE_G
      * to throw an exception.
      */
     public static KEY_VALUE_GENERIC Builder KEY_VALUE_GENERIC builder(int initialCapacity) {
-        return new Builder KEY_VALUE_GENERIC_DIAMOND (initialCapacity);
+        return new Builder KEY_VALUE_GENERIC_DIAMOND(initialCapacity);
     }
 
     public static class Builder KEY_VALUE_GENERIC {
@@ -213,6 +213,14 @@ public abstract class IMMUTABLE_MAP KEY_VALUE_GENERIC implements MAP KEY_VALUE_G
             return this;
         }
 
+        Builder KEY_VALUE_GENERIC combine(Builder KEY_VALUE_GENERIC other) {
+            ensureCapacity(this.size + other.size);
+            System.arraycopy(other.keys, 0, this.keys, this.size, other.size);
+            System.arraycopy(other.values, 0, this.values, this.size, other.size);
+            this.size += other.size;
+            return this;
+        }
+
         public IMMUTABLE_MAP KEY_VALUE_GENERIC build() {
             IMMUTABLE_MAP KEY_VALUE_GENERIC result = construct(size, keys, values);
             // Since duplicates are not allowed, size of map must be same as this size.
@@ -242,12 +250,10 @@ public abstract class IMMUTABLE_MAP KEY_VALUE_GENERIC implements MAP KEY_VALUE_G
         KEY_GENERIC_TYPE[] keyTable = KEY_GENERIC_ARRAY_CAST new KEY_TYPE[tableSize];
         VALUE_GENERIC_TYPE[] valueTable = VALUE_GENERIC_ARRAY_CAST new VALUE_TYPE[tableSize];
         int mask = tableSize - 1;
-        int hashCode = 0;
         boolean hasNull = false;
         VALUE_GENERIC_TYPE valueForNullKey = VALUE_NULL;
         for (int i = 0; i < n; i++) {
             KEY_GENERIC_TYPE key = keys[i];
-            hashCode += KEY2JAVAHASH(key) ^ VALUE2JAVAHASH(values[i]);
             if (KEY_IS_NULL(key)) {
                 if (hasNull) {
                     throw new IllegalArgumentException("Duplicate key for " + key);
@@ -272,7 +278,7 @@ public abstract class IMMUTABLE_MAP KEY_VALUE_GENERIC implements MAP KEY_VALUE_G
                 j++;
             }
         }
-        return new RegularImmutableMap KEY_VALUE_GENERIC_DIAMOND(keyTable, valueTable, hasNull, valueForNullKey, n, hashCode);
+        return new RegularImmutableMap KEY_VALUE_GENERIC_DIAMOND(keyTable, valueTable, hasNull, valueForNullKey, n);
     }
 
     /**
@@ -291,7 +297,7 @@ public abstract class IMMUTABLE_MAP KEY_VALUE_GENERIC implements MAP KEY_VALUE_G
 
     /** Implementation of this immutable map used for 0 or 2+ elements (not 1). */
     private static final class RegularImmutableMap KEY_VALUE_GENERIC extends IMMUTABLE_MAP KEY_VALUE_GENERIC {
-        private static final RegularImmutableMap KEY_VALUE_AS_OBJECT EMPTY = new RegularImmutableMap KEY_VALUE_GENERIC_DIAMOND(null, null, false, VALUE_NULL, 0, 0);
+        private static final RegularImmutableMap KEY_VALUE_AS_OBJECT EMPTY = new RegularImmutableMap KEY_VALUE_GENERIC_DIAMOND(null, null, false, VALUE_NULL, 0);
 
         /**
          * The array of keys.
@@ -313,15 +319,13 @@ public abstract class IMMUTABLE_MAP KEY_VALUE_GENERIC implements MAP KEY_VALUE_G
         private final VALUE_GENERIC_TYPE valueForNullKey;
 
         private final int size;
-        private final int hashCode;
 
-        private RegularImmutableMap(KEY_GENERIC_TYPE[] key, VALUE_GENERIC_TYPE[] value, boolean containsNullKey, VALUE_GENERIC_TYPE valueForNullKey, int size, int hashCode) {
+        private RegularImmutableMap(KEY_GENERIC_TYPE[] key, VALUE_GENERIC_TYPE[] value, boolean containsNullKey, VALUE_GENERIC_TYPE valueForNullKey, int size) {
             this.key = key;
             this.value = value;
             this.containsNullKey = containsNullKey;
             this.valueForNullKey = valueForNullKey;
             this.size = size;
-            this.hashCode = hashCode;
             if (ASSERTS_VALUE) assert containsNullKey || valueForNullKey == VALUE_NULL;
             if (ASSERTS_VALUE) assert key == null || key.length == value.length;
         }
@@ -554,7 +558,7 @@ public abstract class IMMUTABLE_MAP KEY_VALUE_GENERIC implements MAP KEY_VALUE_G
             }
         }
 
-        private final class MapEntrySet extends AbstractObjectSet<MAP.Entry KEY_VALUE_GENERIC> implements FastEntrySet KEY_VALUE_GENERIC {
+        private final class MapEntrySet extends ImmutableObjectSet<MAP.Entry KEY_VALUE_GENERIC> implements FastEntrySet KEY_VALUE_GENERIC {
 
             @Override
             public ObjectIterator<MAP.Entry KEY_VALUE_GENERIC> iterator() { return new EntryIterator(); }
@@ -669,49 +673,13 @@ public abstract class IMMUTABLE_MAP KEY_VALUE_GENERIC implements MAP KEY_VALUE_G
             return new MapEntrySet();
         }
 
-        /**
-         * An iterator on keys.
-         */
-        private final class KeyIterator extends MapIterator implements KEY_ITERATOR KEY_GENERIC {
-            public KeyIterator() { super(); }
-
-            @Override
-            public KEY_GENERIC_TYPE NEXT_KEY() {
-                int nextIndex = nextEntry();
-                return nextIndex == key.length ? KEY_NULL : key[nextIndex];
-            }
-        }
-
-        private final class KeySet extends ABSTRACT_SET KEY_GENERIC {
-
-            @Override
-            public KEY_ITERATOR KEY_GENERIC iterator() { return new KeyIterator(); }
-
-            /** {@inheritDoc} */
-            @Override
-#ifdef JDK_PRIMITIVE_KEY_CONSUMER
-            public void forEach(final JDK_PRIMITIVE_KEY_CONSUMER consumer) {
-#else
-            public void forEach(final KEY_CONSUMER KEY_SUPER_GENERIC consumer) {
-#endif
-                if (key == null) return;
-                if (containsNullKey) consumer.accept(KEY_NULL);
-                for(int pos = key.length; pos-- != 0;) {
-                    final KEY_GENERIC_TYPE k = key[pos];
-                    if (! KEY_IS_NULL(k)) consumer.accept(k);
-                }
-            }
-
-            @Override
-            public int size() { return size; }
-
-            @Override
-            public boolean contains(KEY_TYPE k) { return containsKey(k); }
-        }
-
         @Override
-        public SET KEY_GENERIC keySet() {
-            return new KeySet();
+        public IMMUTABLE_SET KEY_GENERIC keySet() {
+            if (key == null) {
+                return (IMMUTABLE_SET KEY_GENERIC) IMMUTABLE_SET.RegularImmutableSet.EMPTY;
+            }
+
+            return new IMMUTABLE_SET.RegularImmutableSet KEY_GENERIC_DIAMOND(key, containsNullKey, size);
         }
 
         /**
@@ -766,6 +734,17 @@ public abstract class IMMUTABLE_MAP KEY_VALUE_GENERIC implements MAP KEY_VALUE_G
 
         @Override
         public int hashCode() {
+            if (key == null) {
+                return 0;
+            }
+            int hashCode = containsNullKey ? VALUE2JAVAHASH(valueForNullKey) : 0;
+            for (int i = 0; i < key.length; i++) {
+                KEY_GENERIC_TYPE k = key[i];
+                if (KEY_IS_NULL(k)) {
+                    continue;
+                }
+                hashCode += KEY2JAVAHASH(k) ^ VALUE2JAVAHASH(value[i]);
+            }
             return hashCode;
         }
     }
@@ -808,7 +787,7 @@ public abstract class IMMUTABLE_MAP KEY_VALUE_GENERIC implements MAP KEY_VALUE_G
         }
 #endif
 
-        private final class MapEntrySet extends AbstractObjectSet<MAP.Entry KEY_VALUE_GENERIC> implements FastEntrySet KEY_VALUE_GENERIC {
+        private final class MapEntrySet extends ImmutableObjectSet<MAP.Entry KEY_VALUE_GENERIC> implements FastEntrySet KEY_VALUE_GENERIC {
 
             @Override
             public ObjectIterator<MAP.Entry KEY_VALUE_GENERIC> iterator() { return ObjectIterators.singleton((MAP.Entry KEY_VALUE_GENERIC) entry); }
@@ -888,31 +867,9 @@ public abstract class IMMUTABLE_MAP KEY_VALUE_GENERIC implements MAP KEY_VALUE_G
             return new MapEntrySet();
         }
 
-        private final class KeySet extends ABSTRACT_SET KEY_GENERIC {
-
-            @Override
-            public KEY_ITERATOR KEY_GENERIC iterator() { return KEY_ITERATORS.singleton(key); }
-
-            /** {@inheritDoc} */
-            @Override
-#ifdef JDK_PRIMITIVE_KEY_CONSUMER
-            public void forEach(final JDK_PRIMITIVE_KEY_CONSUMER consumer) {
-#else
-            public void forEach(final KEY_CONSUMER KEY_SUPER_GENERIC consumer) {
-#endif
-                consumer.accept(key);
-            }
-
-            @Override
-            public int size() { return 1; }
-
-            @Override
-            public boolean contains(KEY_TYPE k) { return containsKey(k); }
-        }
-
         @Override
-        public SET KEY_GENERIC keySet() {
-            return new KeySet();
+        public IMMUTABLE_SET KEY_GENERIC keySet() {
+            return new IMMUTABLE_SET.SingletonImmutableSet KEY_GENERIC_DIAMOND(key);
         }
 
         @Override
@@ -986,5 +943,8 @@ public abstract class IMMUTABLE_MAP KEY_VALUE_GENERIC implements MAP KEY_VALUE_G
     public boolean isEmpty() {
         return size() == 0;
     }
+
+    @Override
+    public abstract IMMUTABLE_SET KEY_GENERIC keySet();
 }
 

--- a/drv/ImmutableSet.drv
+++ b/drv/ImmutableSet.drv
@@ -20,9 +20,17 @@ import java.util.Collections;
 import java.util.NoSuchElementException;
 import java.util.Spliterator;
 import java.util.Spliterators;
+import java.util.stream.StreamSupport;
 
 import it.unimi.dsi.fastutil.Hash;
 import it.unimi.dsi.fastutil.HashCommon;
+
+#ifdef JDK_PRIMITIVE_STREAM
+import java.util.stream.JDK_PRIMITIVE_STREAM;
+#if KEY_WIDENED
+import WIDENED_KEY_PACKAGE.WIDENED_KEY_ITERATORS;
+#endif
+#endif
 
 /**
  * A type-specific immutable {@link java.util.Set}. It provides some additional
@@ -37,61 +45,79 @@ import it.unimi.dsi.fastutil.HashCommon;
  * methods are adapted from Guava implementation which is licensed under
  * Apache 2.0.
  */
-public abstract class IMMUTABLE_SET extends ABSTRACT_SET {
+public abstract class IMMUTABLE_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC {
 
     /** Returns the empty immutable set. */
-    public static IMMUTABLE_SET of() {
-        return RegularImmutableSet.EMPTY;
+    public static KEY_GENERIC IMMUTABLE_SET KEY_GENERIC of() {
+        return (IMMUTABLE_SET KEY_GENERIC) RegularImmutableSet.EMPTY;
     }
 
     /** Returns an immutable set containing {@code element}. */
-    public static IMMUTABLE_SET of(KEY_TYPE element) {
+    public static KEY_GENERIC IMMUTABLE_SET KEY_GENERIC of(KEY_GENERIC_TYPE element) {
         return new SingletonImmutableSet(element);
     }
 
     /**
      * Returns an immutable set containing the given elements.
      */
-    public static IMMUTABLE_SET of(KEY_TYPE... elements) {
-    	// Make a copy of the provided elements array since construct
+    public static KEY_GENERIC IMMUTABLE_SET KEY_GENERIC of(KEY_GENERIC_TYPE... elements) {
+        // Make a copy of the provided elements array since construct
         // method modifies the provided array and we don't own the
         // provided elements array here.
-		KEY_TYPE[] copy = Arrays.copyOf(elements, elements.length);
+        KEY_GENERIC_TYPE[] copy = Arrays.copyOf(elements, elements.length);
         return construct(elements.length, copy);
     }
 
     /**
      * Returns an immutable set containing each of {@code elements}.
      */
-    public static IMMUTABLE_SET copyOf(Collection<KEY_GENERIC_CLASS> elements) {
+    public static KEY_GENERIC IMMUTABLE_SET KEY_GENERIC copyOf(Collection<KEY_GENERIC_CLASS> elements) {
         if (elements instanceof IMMUTABLE_SET) {
-            return (IMMUTABLE_SET) elements;
+            return (IMMUTABLE_SET KEY_GENERIC) elements;
         }
         if (elements instanceof COLLECTION) {
-            return construct(elements.size(), ((COLLECTION) elements).TO_KEY_ARRAY());
+            COLLECTION KEY_GENERIC c = (COLLECTION) elements;
+            return construct(elements.size(), KEY_GENERIC_ARRAY_CAST c.TO_KEY_ARRAY());
         }
-        return construct(elements.size(), new ARRAY_LIST(elements).TO_KEY_ARRAY());
+        KEY_GENERIC_TYPE[] copy = KEY_GENERIC_ARRAY_CAST new KEY_TYPE[elements.size()];
+        int index = 0;
+        for (KEY_TYPE e : elements) {
+            copy[index] = KEY_GENERIC_CAST e;
+            index++;
+        }
+        return construct(elements.size(), copy);
     }
 
-#ifdef JDK_PRIMITIVE_SPLITERATOR
+#if defined JDK_PRIMITIVE_SPLITERATOR && !KEY_WIDENED
     @Override
     public abstract JDK_PRIMITIVE_SPLITERATOR spliterator();
 #endif
 
+#ifdef JDK_PRIMITIVE_STREAM
+    @Override
+    public JDK_PRIMITIVE_STREAM JDK_PRIMITIVE_STREAM_METHOD() {
+#if KEY_WIDENED
+        return StreamSupport.JDK_PRIMITIVE_STREAM_METHOD(Spliterators.spliterator(WIDENED_KEY_ITERATORS.wrap(iterator()), size(), Spliterator.IMMUTABLE | Spliterator.NONNULL | Spliterator.ORDERED), false);
+#else
+        return StreamSupport.JDK_PRIMITIVE_STREAM_METHOD(spliterator(), false);
+#endif
+    }
+#endif
+
     /** Returns a new Builder. */
-    public static Builder builder() {
-        return new Builder();
+    public static KEY_GENERIC Builder KEY_GENERIC builder() {
+        return new Builder KEY_GENERIC_DIAMOND();
     }
 
     /**
      * Returns a new Builder which is initialized with the provided initial
      * capacity.
     */
-    public static Builder builder(int initialCapacity) {
-        return new Builder(initialCapacity);
+    public static KEY_GENERIC Builder KEY_GENERIC builder(int initialCapacity) {
+        return new Builder KEY_GENERIC_DIAMOND(initialCapacity);
     }
 
-    public static class Builder extends IMMUTABLES.ArrayBasedBuilder {
+    public static class Builder KEY_GENERIC extends IMMUTABLES.ArrayBasedBuilder KEY_GENERIC {
         public Builder(int initialCapacity) {
             super(initialCapacity);
         }
@@ -101,43 +127,43 @@ public abstract class IMMUTABLE_SET extends ABSTRACT_SET {
         }
 
         @Override
-        public Builder add(KEY_TYPE element) {
+        public Builder KEY_GENERIC add(KEY_GENERIC_TYPE element) {
             super.add(element);
             return this;
         }
 
         @Override
-        public Builder add(KEY_TYPE... elements) {
+        public Builder KEY_GENERIC add(KEY_GENERIC_TYPE... elements) {
             super.add(elements);
             return this;
         }
 
         @Override
-        public Builder addAll(LIST elements) {
+        public Builder KEY_GENERIC addAll(LIST KEY_GENERIC elements) {
             super.addAll(elements);
             return this;
         }
 
         @Override
-        public Builder addAll(COLLECTION elements) {
+        public Builder KEY_GENERIC addAll(COLLECTION KEY_GENERIC elements) {
             super.addAll(elements);
             return this;
         }
 
         @Override
-        public Builder addAll(Iterable<KEY_GENERIC_CLASS> elements) {
+        public Builder KEY_GENERIC addAll(Iterable<KEY_GENERIC_CLASS> elements) {
             super.addAll(elements);
             return this;
         }
 
         @Override
-        Builder combine(IMMUTABLES.ArrayBasedBuilder other) {
+        Builder KEY_GENERIC combine(IMMUTABLES.ArrayBasedBuilder KEY_GENERIC other) {
             super.combine(other);
             return this;
         }
 
-        public IMMUTABLE_SET build() {
-            IMMUTABLE_SET result = construct(size, elements);
+        public IMMUTABLE_SET KEY_GENERIC build() {
+            IMMUTABLE_SET KEY_GENERIC result = construct(size, elements);
             // construct has the side effect of de-duping contents, so we
             // update size accordingly.
             size = result.size();
@@ -150,7 +176,7 @@ public abstract class IMMUTABLE_SET extends ABSTRACT_SET {
      * specified array. Note that this method modifies the provided
      * {@code elements} array.
      */
-    private static IMMUTABLE_SET construct(int n, KEY_TYPE... elements) {
+    private static KEY_GENERIC IMMUTABLE_SET KEY_GENERIC construct(int n, KEY_GENERIC_TYPE... elements) {
         switch (n) {
             case 0:
                 return of();
@@ -159,67 +185,65 @@ public abstract class IMMUTABLE_SET extends ABSTRACT_SET {
             default:
                 // continue below to handle the general case
         }
-        int nonZeroCount = nonZeroCount(elements, n);
-        if (nonZeroCount == 0) {
-            // All elements are zero.
-            return new SingletonImmutableSet((KEY_TYPE) 0);
+        int nonNullCount = nonNullCount(elements, n);
+        if (nonNullCount == 0) {
+            // All elements are null.
+            return new SingletonImmutableSet(KEY_NULL);
         }
 
-        int tableSize = chooseTableSize(nonZeroCount);
-        KEY_TYPE[] table = new KEY_TYPE[tableSize];
+        int tableSize = chooseTableSize(nonNullCount);
+        KEY_GENERIC_TYPE[] table = KEY_GENERIC_ARRAY_CAST new KEY_TYPE[tableSize];
         int mask = tableSize - 1;
-        int hashCode = 0;
         int uniques = 0;
-        boolean hasZero = false;
+        boolean hasNull = false;
         for (int i = 0; i < n; i++) {
-            KEY_TYPE element = elements[i];
-            if (element == 0) {
-                hasZero = true;
+            KEY_GENERIC_TYPE element = elements[i];
+            if (KEY_IS_NULL(element)) {
+                hasNull = true;
                 continue;
             }
             int j = KEY2INTHASH(element);
             while (true) {
                 int index = j & mask;
-                KEY_TYPE value = table[index];
-                if (value == 0) {
+                KEY_GENERIC_TYPE value = table[index];
+                if (KEY_IS_NULL(value)) {
                     // Came to an empty slot. Put the element here.
                     elements[uniques++] = element;
                     table[index] = element;
-                    hashCode += KEY2JAVAHASH(element);
                     break;
                 }
-                if (value == element) {
+                if (KEY_EQUALS_NOT_NULL(value, element)) {
                     break;
                 }
                 j++;
             }
         }
-        if (uniques == 1 && !hasZero) {
+        if (uniques == 1 && !hasNull) {
             return new SingletonImmutableSet(elements[0]);
         }
-        int size = uniques + (hasZero ? 1 : 0);
+        int size = uniques + (hasNull ? 1 : 0);
         if (tableSize != chooseTableSize(uniques)) {
             // Resize the table when the array includes too many duplicates.
-            if (hasZero) {
-                elements[uniques] = 0;
+            if (hasNull) {
+                elements[uniques] = KEY_NULL;
             }
             return construct(size, elements);
         }
-        return new RegularImmutableSet(table, mask, hasZero, size, hashCode);
+        return new RegularImmutableSet KEY_GENERIC_DIAMOND(table, hasNull, size);
     }
 
     /**
-     * Returns the number of non-zero elements in [0, size) range in the
+     * Returns the number of non-null elements in [0, size) range in the
      * provided array.
      */
-    private static int nonZeroCount(KEY_TYPE[] elements, int size) {
-        int nonZeroCount = 0;
+    private static KEY_GENERIC int nonNullCount(KEY_GENERIC_TYPE[] elements, int size) {
+        int nonNullCount = 0;
         for (int i = 0; i < size; ++i) {
-            if (elements[i] != 0) {
-                ++nonZeroCount;
+            if (!(KEY_IS_NULL(elements[i]))) {
+                ++nonNullCount;
             }
         }
-        return nonZeroCount;
+        return nonNullCount;
     }
 
     /**
@@ -235,42 +259,38 @@ public abstract class IMMUTABLE_SET extends ABSTRACT_SET {
     }
 
     /** Implementation of this immutable set used for 0 or 2+ elements (not 1). */
-    private static class RegularImmutableSet extends IMMUTABLE_SET {
-        private static final RegularImmutableSet EMPTY = new RegularImmutableSet(null, 0, false, 0, 0);
+    static class RegularImmutableSet KEY_GENERIC extends IMMUTABLE_SET KEY_GENERIC {
+        static final RegularImmutableSet KEY_AS_OBJECT EMPTY = new RegularImmutableSet KEY_GENERIC_DIAMOND(null, false, 0);
 
         /** The array of elements in hashed positions. */
-        private final KEY_TYPE[] table;
-        /** 'and' with an int to get a valid table index. */
-        private final int mask;
-        /** Whether this set contains zero. */
-        private final boolean hasZero;
+        private final KEY_GENERIC_TYPE[] table;
+        /** Whether this set contains null. */
+        private final boolean hasNull;
         private final int size;
-        private final int hashCode;
 
-        private RegularImmutableSet(KEY_TYPE[] table, int mask, boolean hasZero, int size, int hashCode) {
+        RegularImmutableSet(KEY_GENERIC_TYPE[] table, boolean hasNull, int size) {
             this.table = table;
-            this.mask = mask;
-            this.hasZero = hasZero;
+            this.hasNull = hasNull;
             this.size = size;
-            this.hashCode = hashCode;
         }
 
         @Override
         public boolean contains(KEY_TYPE k) {
-            if (k == 0) {
-                return hasZero;
+            if (KEY_IS_NULL(k)) {
+                return hasNull;
             }
             if (table == null) {
                 return false;
             }
+            int mask = table.length - 1;
             int i = KEY2INTHASH(k);
             while (true) {
                 i &= mask;
-                KEY_TYPE candidate = table[i];
-                if (candidate == 0) {
+                KEY_GENERIC_TYPE candidate = table[i];
+                if (KEY_IS_NULL(candidate)) {
                     return false;
                 }
-                if (candidate == k) {
+                if (KEY_EQUALS_NOT_NULL(candidate, k)) {
                     return true;
                 }
                 i++;
@@ -278,14 +298,14 @@ public abstract class IMMUTABLE_SET extends ABSTRACT_SET {
         }
 
         @Override
-        public KEY_ITERATOR iterator() {
+        public KEY_ITERATOR KEY_GENERIC iterator() {
             if (table == null) {
                 return ITERATORS.EMPTY_ITERATOR;
             }
             return new SetIterator();
         }
 
-#ifdef JDK_PRIMITIVE_SPLITERATOR
+#if defined JDK_PRIMITIVE_SPLITERATOR  && !KEY_WIDENED
 		@Override
         public JDK_PRIMITIVE_SPLITERATOR spliterator() {
             return Spliterators.spliterator(iterator(), size, Spliterator.IMMUTABLE | Spliterator.NONNULL | Spliterator.DISTINCT);
@@ -299,6 +319,17 @@ public abstract class IMMUTABLE_SET extends ABSTRACT_SET {
 
         @Override
         public int hashCode() {
+            if (table == null) {
+                return 0;
+            }
+            int hashCode = 0;
+            for (int i = 0; i < table.length; i++) {
+                KEY_GENERIC_TYPE element = table[i];
+                if (KEY_IS_NULL(element)) {
+                    continue;
+                }
+                hashCode += KEY2JAVAHASH(element);
+            }
             return hashCode;
         }
 
@@ -307,14 +338,11 @@ public abstract class IMMUTABLE_SET extends ABSTRACT_SET {
             if (other == this) {
                 return true;
             }
-            if (other instanceof IMMUTABLE_SET && hashCode != other.hashCode()) {
-                return false;
-            }
             return super.equals(other);
         }
 
         /** An iterator over a hash set. */
-        private class SetIterator implements KEY_ITERATOR {
+        private class SetIterator implements KEY_ITERATOR KEY_GENERIC {
             /**
              * The index of the last entry returned; initially,
              * {@link #size}.
@@ -327,8 +355,8 @@ public abstract class IMMUTABLE_SET extends ABSTRACT_SET {
              */
             private int c = size;
 
-            /** Whether zero should be returned. */
-            private boolean mustReturnZero = hasZero;
+            /** Whether null should be returned. */
+            private boolean mustReturnNull = hasNull;
 
             @Override
             public boolean hasNext() {
@@ -336,18 +364,18 @@ public abstract class IMMUTABLE_SET extends ABSTRACT_SET {
             }
 
             @Override
-            public KEY_TYPE NEXT_KEY() {
+            public KEY_GENERIC_TYPE NEXT_KEY() {
                 if (!hasNext()) {
                     throw new NoSuchElementException();
                 }
                 c--;
-                if (mustReturnZero) {
-                    mustReturnZero = false;
-                    return 0;
+                if (mustReturnNull) {
+                    mustReturnNull = false;
+                    return KEY_NULL;
                 }
                 while (true) {
                     --pos;
-                    if (table[pos] != 0) {
+                    if (!KEY_IS_NULL(table[pos])) {
                         return table[pos];
                     }
                 }
@@ -356,16 +384,16 @@ public abstract class IMMUTABLE_SET extends ABSTRACT_SET {
     }
 
     /** Implementation of this immutable set with exactly one element. */
-    private static class SingletonImmutableSet extends IMMUTABLE_SET {
-        private final KEY_TYPE element;
+    static class SingletonImmutableSet KEY_GENERIC extends IMMUTABLE_SET KEY_GENERIC {
+        private final KEY_GENERIC_TYPE element;
 
-        private SingletonImmutableSet(KEY_TYPE element) {
+        SingletonImmutableSet(KEY_GENERIC_TYPE element) {
             this.element = element;
         }
 
         @Override
         public boolean contains(KEY_TYPE k) {
-            return element == k;
+            return KEY_EQUALS(element, k);
         }
 
         @Override
@@ -383,9 +411,6 @@ public abstract class IMMUTABLE_SET extends ABSTRACT_SET {
             if (other == this) {
                 return true;
             }
-            if (other instanceof IMMUTABLE_SET && hashCode() != other.hashCode()) {
-                return false;
-            }
             return super.equals(other);
         }
 
@@ -394,7 +419,7 @@ public abstract class IMMUTABLE_SET extends ABSTRACT_SET {
             return ITERATORS.singleton(element);
         }
 
-#ifdef JDK_PRIMITIVE_SPLITERATOR
+#if defined JDK_PRIMITIVE_SPLITERATOR  && !KEY_WIDENED
 		@Override
         public JDK_PRIMITIVE_SPLITERATOR spliterator() {
             return IMMUTABLES.singletonSpliterator(element);

--- a/drv/Immutables.drv
+++ b/drv/Immutables.drv
@@ -23,34 +23,41 @@ final class IMMUTABLES {
 
     private IMMUTABLES() { }
 
-    private abstract static class Builder {
+    private abstract static class Builder KEY_GENERIC {
         Builder() { }
 
-        public abstract Builder add(KEY_TYPE element);
+        public abstract Builder KEY_GENERIC add(KEY_GENERIC_TYPE element);
 
-        public Builder add(KEY_TYPE... elements) {
-            for (KEY_TYPE element : elements) {
+        public Builder KEY_GENERIC add(KEY_GENERIC_TYPE... elements) {
+            for (KEY_GENERIC_TYPE element : elements) {
                 add(element);
             }
             return this;
         }
 
-        public Builder addAll(Iterable<KEY_GENERIC_CLASS> elements) {
-            for (KEY_TYPE element : elements) {
+        public Builder KEY_GENERIC addAll(Iterable<KEY_GENERIC_CLASS> elements) {
+            if (elements instanceof COLLECTION) {
+                KEY_ITERATOR itr = ((COLLECTION KEY_GENERIC) elements).iterator();
+                while (itr.hasNext()) {
+                    add(KEY_GENERIC_CAST itr.NEXT_KEY());
+                }
+                return this;
+            }
+            for (KEY_GENERIC_TYPE element : elements) {
                 add(element);
             }
             return this;
         }
     }
 
-    abstract static class ArrayBasedBuilder extends Builder {
+    abstract static class ArrayBasedBuilder KEY_GENERIC extends Builder KEY_GENERIC {
         static final int DEFAULT_INITIAL_CAPACITY = 4;
 
-        protected KEY_TYPE[] elements;
+        protected KEY_GENERIC_TYPE[] elements;
         protected int size;
 
         ArrayBasedBuilder(int initialCapacity) {
-            elements = new KEY_TYPE[initialCapacity];
+            elements = KEY_GENERIC_ARRAY_CAST new KEY_TYPE[initialCapacity];
             size = 0;
         }
 
@@ -62,21 +69,21 @@ final class IMMUTABLES {
         }
 
         @Override
-        public ArrayBasedBuilder add(KEY_TYPE element) {
+        public ArrayBasedBuilder KEY_GENERIC add(KEY_GENERIC_TYPE element) {
             ensureCapacity(size + 1);
             elements[size++] = element;
             return this;
         }
 
         @Override
-        public ArrayBasedBuilder add(KEY_TYPE... elements) {
+        public ArrayBasedBuilder KEY_GENERIC add(KEY_GENERIC_TYPE... elements) {
             ensureCapacity(size + elements.length);
             System.arraycopy(elements, 0, this.elements, size, elements.length);
             size += elements.length;
             return this;
         }
 
-        public ArrayBasedBuilder addAll(LIST elements) {
+        public ArrayBasedBuilder KEY_GENERIC addAll(LIST KEY_GENERIC elements) {
             int n = elements.size();
             ensureCapacity(size + n);
             for (int i = 0; i < n; ++i) {
@@ -85,18 +92,18 @@ final class IMMUTABLES {
             return this;
         }
 
-        public ArrayBasedBuilder addAll(COLLECTION elements) {
+        public ArrayBasedBuilder KEY_GENERIC addAll(COLLECTION KEY_GENERIC elements) {
              int n = elements.size();
              ensureCapacity(size + n);
              KEY_ITERATOR iterator = elements.iterator();
              while (iterator.hasNext()) {
-                 this.elements[size++] = iterator.NEXT_KEY();
+                 this.elements[size++] = KEY_GENERIC_CAST iterator.NEXT_KEY();
              }
              return this;
          }
 
         @Override
-        public ArrayBasedBuilder addAll(Iterable<KEY_GENERIC_CLASS> elements) {
+        public ArrayBasedBuilder KEY_GENERIC addAll(Iterable<KEY_GENERIC_CLASS> elements) {
             if (elements instanceof Collection) {
                 Collection<?> collection = (Collection<?>) elements;
                 ensureCapacity(size + collection.size());
@@ -105,7 +112,7 @@ final class IMMUTABLES {
             return this;
         }
 
-        ArrayBasedBuilder combine(ArrayBasedBuilder other) {
+        ArrayBasedBuilder KEY_GENERIC combine(ArrayBasedBuilder KEY_GENERIC other) {
             ensureCapacity(size + other.size);
             System.arraycopy(other.elements, 0, elements, size, other.size);
             size += other.size;

--- a/drv/Iterators.drv
+++ b/drv/Iterators.drv
@@ -940,6 +940,46 @@ public final class ITERATORS {
 
 #endif
 
+#if SMALL_TYPES && (KEY_CLASS_Integer || KEY_CLASS_Long || KEY_CLASS_Float || KEY_CLASS_Double)
+
+		/** A wrapper promoting the results of a CharIterator. */
+
+		protected static class CharIteratorWrapper implements KEY_ITERATOR {
+			final it.unimi.dsi.fastutil.chars.CharIterator iterator;
+
+			public CharIteratorWrapper(final it.unimi.dsi.fastutil.chars.CharIterator iterator) {
+				this.iterator = iterator;
+			}
+
+			@Override
+			public boolean hasNext() { return iterator.hasNext(); }
+
+			@Deprecated
+			@Override
+			public KEY_GENERIC_CLASS next() {
+				return KEY_GENERIC_CLASS.valueOf((int) iterator.nextChar());
+			}
+
+			@Override
+			public KEY_TYPE NEXT_KEY() { return (int) iterator.nextChar(); }
+
+			@Override
+			public void remove() { iterator.remove(); }
+
+			@Override
+			public int skip(final int n) { return iterator.skip(n); }
+		}
+
+		/** Returns an iterator backed by the specified char iterator.
+		 * @param iterator a char iterator.
+		 * @return an iterator backed by the specified char iterator.
+		 */
+		public static KEY_ITERATOR wrap(final it.unimi.dsi.fastutil.chars.CharIterator iterator) {
+			return new CharIteratorWrapper(iterator);
+		}
+
+#endif
+
 #if KEY_CLASS_Long || KEY_CLASS_Double
 
   	/** A wrapper promoting the results of an IntIterator. */

--- a/drv/MapCollectors.drv
+++ b/drv/MapCollectors.drv
@@ -1,0 +1,72 @@
+package PACKAGE;
+
+import java.util.Map;
+import java.util.stream.Collector;
+
+public final class MAP_COLLECTORS {
+
+    private MAP_COLLECTORS() {
+    }
+
+    public static KEY_VALUE_GENERIC_COLLECTOR Collector<COLLECTOR_GENERIC, MAP KEY_VALUE_GENERIC, MAP KEY_VALUE_GENERIC> toMap(COLLECTOR_KEY_FUNCTION keyFunction, COLLECTOR_VALUE_FUNCTION valueFunction) {
+        return Collector.of(
+                OPEN_HASH_MAP KEY_VALUE_GENERIC::new,
+                (m, e) -> m.put((KEY_GENERIC_TYPE) keyFunction.COLLECTOR_KEY_APPLY_METHOD(e), (VALUE_GENERIC_TYPE) valueFunction.COLLECTOR_VALUE_APPLY_METHOD(e)),
+                (m1, m2) -> {
+                    m1.putAll(m2);
+                    return m1;
+                });
+    }
+
+    public static KEY_VALUE_GENERIC Collector<MAP.Entry KEY_VALUE_GENERIC, MAP KEY_VALUE_GENERIC, MAP KEY_VALUE_GENERIC> toMap() {
+        return toMap(MAP.Entry::ENTRY_GET_KEY, MAP.Entry::ENTRY_GET_VALUE);
+    }
+
+    /**
+     * Use this method only if stream has non-fastutil entry objects (i.e entry key/value are boxed types), and it's
+     * not possible to avoid such entry objects without incurring extra overhead of creating fastutil entry objects.
+     * Otherwise, if stream was already mapped to fastutil entry objects, the regular one above should be used.
+     */
+    public static KEY_VALUE_GENERIC Collector<Map.Entry<? extends KEY_GENERIC_CLASS, ? extends VALUE_GENERIC_CLASS>, MAP KEY_VALUE_GENERIC, MAP KEY_VALUE_GENERIC> toMapSlow() {
+        return toMap(MAP_COLLECTORS::getKey, MAP_COLLECTORS::getValue);
+    }
+
+    public static KEY_VALUE_GENERIC_COLLECTOR Collector<COLLECTOR_GENERIC, ?, IMMUTABLE_MAP KEY_VALUE_GENERIC> toImmutableMap(COLLECTOR_KEY_FUNCTION keyFunction, COLLECTOR_VALUE_FUNCTION valueFunction) {
+        return Collector.of(
+                IMMUTABLE_MAP.Builder KEY_VALUE_GENERIC::new,
+                (m, e) -> m.put((KEY_GENERIC_TYPE) keyFunction.COLLECTOR_KEY_APPLY_METHOD(e), (VALUE_GENERIC_TYPE) valueFunction.COLLECTOR_VALUE_APPLY_METHOD(e)),
+                IMMUTABLE_MAP.Builder::combine,
+                IMMUTABLE_MAP.Builder::build);
+    }
+
+    public static KEY_VALUE_GENERIC Collector<MAP.Entry KEY_VALUE_GENERIC, ?, IMMUTABLE_MAP KEY_VALUE_GENERIC> toImmutableMap() {
+        return toImmutableMap(MAP.Entry::ENTRY_GET_KEY, MAP.Entry::ENTRY_GET_VALUE);
+    }
+
+    /**
+     * Use this method only if stream has non-fastutil entry objects (i.e entry key/value are boxed types), and it's
+     * not possible to avoid such entry objects without incurring extra overhead of creating fastutil entry objects.
+     * Otherwise, if stream was already mapped to fastutil entry objects, the regular one above should be used.
+     */
+    public static KEY_VALUE_GENERIC Collector<Map.Entry<? extends KEY_GENERIC_CLASS, ? extends VALUE_GENERIC_CLASS>, ?, IMMUTABLE_MAP KEY_VALUE_GENERIC> toImmutableMapSlow() {
+        return toImmutableMap(MAP_COLLECTORS::getKey, MAP_COLLECTORS::getValue);
+    }
+
+    private static KEY_VALUE_GENERIC KEY_GENERIC_TYPE getKey(Map.Entry<? extends KEY_GENERIC_CLASS, ? extends VALUE_GENERIC_CLASS> e) {
+        if (e instanceof MAP.Entry) {
+            MAP.Entry KEY_VALUE_GENERIC entry = (MAP.Entry) e;
+            return entry.ENTRY_GET_KEY();
+        } else {
+            return KEY_OBJ2TYPE(KEY_GENERIC_CAST e.getKey());
+        }
+    }
+
+    private static KEY_VALUE_GENERIC VALUE_GENERIC_TYPE getValue(Map.Entry<? extends KEY_GENERIC_CLASS, ? extends VALUE_GENERIC_CLASS> e) {
+        if (e instanceof MAP.Entry) {
+            MAP.Entry KEY_VALUE_GENERIC entry = (MAP.Entry) e;
+            return entry.ENTRY_GET_VALUE();
+        } else {
+            return VALUE_OBJ2TYPE(VALUE_GENERIC_CAST e.getValue());
+        }
+    }
+}

--- a/gencsource.sh
+++ b/gencsource.sh
@@ -132,14 +132,16 @@ $(if [[ "${CLASS[$k]}" != "" ]]; then\
 			echo "#define JDK_PRIMITIVE_KEY_CONSUMER java.util.function.${TYPE_CAP[$wk]}Consumer\\n";\
 			echo "#define JDK_PRIMITIVE_PREDICATE java.util.function.${TYPE_CAP[$wk]}Predicate\\n";\
 			echo "#define JDK_PRIMITIVE_ITERATOR PrimitiveIterator.Of${TYPE_CAP[$wk]}\\n";\
+			echo "#define JDK_PRIMITIVE_SPLITERATOR Spliterator.Of${TYPE_CAP[$wk]}\\n";\
+			echo "#define JDK_PRIMITIVE_STREAM ${TYPE_CAP[$wk]}Stream\\n";\
+			echo "#define JDK_PRIMITIVE_STREAM_METHOD ${TYPE[$wk]}Stream\\n";\
+			echo "#define WIDENED_KEY_PACKAGE it.unimi.dsi.fastutil.${TYPE_LC2[$wk]}s\n";\
+			echo "#define WIDENED_KEY_ITERATORS ${TYPE_CAP2[$wk]}Iterators\n";\
+			echo "#define JDK_PRIMITIVE_OBJKEY_CONSUMER Obj${TYPE_CAP[$wk]}Consumer\\n";\
 		fi\
 	else\
 		echo "#define KEYS_REFERENCE 1\\n";\
 		echo "#define JDK_KEY_TO_GENERIC_FUNCTION java.util.function.Function\\n";\
-	fi;\
-	if [[ "${CLASS[$k]}" == "Integer" || "${CLASS[$k]}" == "Long" || "${CLASS[$k]}" == "Double" ]]; then\
-		echo "#define JDK_PRIMITIVE_ITERATOR PrimitiveIterator.Of${TYPE_CAP[$k]}\\n";\
-		echo "#define JDK_PRIMITIVE_SPLITERATOR Spliterator.Of${TYPE_CAP[$k]}\\n";\
 	fi;\
  fi)\
 $(if [[ "${CLASS[$v]}" != "" ]]; then\
@@ -177,6 +179,7 @@ $(if [[ "${CLASS[$k]}" != "" && "${CLASS[$v]}" != "" ]]; then\
 			echo "#define JDK_PRIMITIVE_FUNCTION_APPLY test\\n";\
 		fi;\
 	fi;\
+	echo "#define COLLECTOR_GENERIC T\\n";\
  fi)\
 $(if [[ "${CLASS[$k]}" != "" ]]; then\
 	if [[ "${TYPE[$wk]}" == "${TYPE[$k]}" ]]; then\
@@ -226,6 +229,9 @@ fi)\
 "#define SUPPRESS_WARNINGS_KEY_UNCHECKED @SuppressWarnings(\"unchecked\")\n"\
 "#define SUPPRESS_WARNINGS_KEY_RAWTYPES @SuppressWarnings(\"rawtypes\")\n"\
 "#define SUPPRESS_WARNINGS_KEY_UNCHECKED_RAWTYPES @SuppressWarnings({\"unchecked\",\"rawtypes\"})\n"\
+"#define KEY_AS_OBJECT <Object>\n"\
+"#define COLLECTOR_KEY_FUNCTION java.util.function.Function<T, ? extends K>\n"\
+"#define COLLECTOR_KEY_APPLY_METHOD apply\n"\
 "#if defined(Custom)\n"\
 "#define SUPPRESS_WARNINGS_CUSTOM_KEY_UNCHECKED @SuppressWarnings(\"unchecked\")\n"\
 "#else\n"\
@@ -249,6 +255,9 @@ fi)\
 "#define SUPPRESS_WARNINGS_KEY_RAWTYPES\n"\
 "#define SUPPRESS_WARNINGS_KEY_UNCHECKED_RAWTYPES\n"\
 "#define SUPPRESS_WARNINGS_CUSTOM_KEY_UNCHECKED\n"\
+"#define KEY_AS_OBJECT\n"\
+"#define COLLECTOR_KEY_FUNCTION java.util.function.To${TYPE_CAP[$wk]}Function<T>\n"\
+"#define COLLECTOR_KEY_APPLY_METHOD applyAs${TYPE_CAP[$wk]}\n"\
 "#endif\n"\
 \
 "#if VALUES_REFERENCE\n"\
@@ -264,6 +273,8 @@ fi)\
 "#define VALUE_GENERIC_ARRAY_CAST (V[])\n"\
 "#define SUPPRESS_WARNINGS_VALUE_UNCHECKED @SuppressWarnings(\"unchecked\")\n"\
 "#define SUPPRESS_WARNINGS_VALUE_RAWTYPES @SuppressWarnings(\"rawtypes\")\n"\
+"#define COLLECTOR_VALUE_FUNCTION java.util.function.Function<T, ? extends V>\n"\
+"#define COLLECTOR_VALUE_APPLY_METHOD apply\n"\
 "#else\n"\
 "#define VALUE_GENERIC_CLASS VALUE_CLASS\n"\
 "#define VALUE_GENERIC_TYPE VALUE_TYPE\n"\
@@ -277,6 +288,8 @@ fi)\
 "#define VALUE_GENERIC_ARRAY_CAST\n"\
 "#define SUPPRESS_WARNINGS_VALUE_UNCHECKED\n"\
 "#define SUPPRESS_WARNINGS_VALUE_RAWTYPES\n"\
+"#define COLLECTOR_VALUE_FUNCTION java.util.function.To${TYPE_CAP[$wv]}Function<T>\n"\
+"#define COLLECTOR_VALUE_APPLY_METHOD applyAs${TYPE_CAP[$wv]}\n"\
 "#endif\n"\
 \
 "#if KEYS_REFERENCE\n"\
@@ -285,11 +298,13 @@ fi)\
 "#define KEY_VALUE_GENERIC_DIAMOND <>\n"\
 "#define KEY_VALUE_EXTENDS_GENERIC <? extends K, ? extends V>\n"\
 "#define KEY_VALUE_AS_OBJECT <Object, Object>\n"\
+"#define KEY_VALUE_GENERIC_COLLECTOR <T, K, V>\n"\
 "#else\n"\
 "#define KEY_VALUE_GENERIC <K>\n"\
 "#define KEY_VALUE_GENERIC_DIAMOND <>\n"\
 "#define KEY_VALUE_EXTENDS_GENERIC <? extends K>\n"\
 "#define KEY_VALUE_AS_OBJECT <Object>\n"\
+"#define KEY_VALUE_GENERIC_COLLECTOR <T, K>\n"\
 "#endif\n"\
 "#else\n"\
 "#if VALUES_REFERENCE\n"\
@@ -297,11 +312,13 @@ fi)\
 "#define KEY_VALUE_GENERIC_DIAMOND <>\n"\
 "#define KEY_VALUE_EXTENDS_GENERIC <? extends V>\n"\
 "#define KEY_VALUE_AS_OBJECT <Object>\n"\
+"#define KEY_VALUE_GENERIC_COLLECTOR <T, V>\n"\
 "#else\n"\
 "#define KEY_VALUE_GENERIC\n"\
 "#define KEY_VALUE_GENERIC_DIAMOND\n"\
 "#define KEY_VALUE_EXTENDS_GENERIC\n"\
 "#define KEY_VALUE_AS_OBJECT\n"\
+"#define KEY_VALUE_GENERIC_COLLECTOR <T>\n"\
 "#endif\n"\
 "#endif\n"\
 \
@@ -417,6 +434,7 @@ fi)\
 "#define BIG_LISTS ${TYPE_CAP[$k]}BigLists\n"\
 "#define IMMUTABLES ${TYPE_CAP[$k]}Immutables\n"\
 "#define MAPS ${TYPE_CAP[$k]}2${TYPE_CAP[$v]}Maps\n"\
+"#define MAP_COLLECTORS ${TYPE_CAP[$k]}2${TYPE_CAP[$v]}Collectors\n"\
 "#define FUNCTIONS ${TYPE_CAP[$k]}2${TYPE_CAP[$v]}Functions\n"\
 "#define SORTED_MAPS ${TYPE_CAP[$k]}2${TYPE_CAP[$v]}SortedMaps\n"\
 "#define PRIORITY_QUEUES ${TYPE_CAP2[$k]}PriorityQueues\n"\
@@ -428,7 +446,7 @@ fi)\
 "#define ITERATORS ${TYPE_CAP2[$k]}Iterators\n"\
 "#define BIG_LIST_ITERATORS ${TYPE_CAP2[$k]}BigListIterators\n"\
 "#define COMPARATORS ${TYPE_CAP2[$k]}Comparators\n"\
-"#define COLLECTORS ${TYPE_CAP2[$k]}Collectors\n"\
+"#define COLLECTORS ${TYPE_CAP[$k]}Collectors\n"\
 \
 \
 "/* Static containers (values) */\n"\

--- a/makefile
+++ b/makefile
@@ -181,7 +181,7 @@ $(IMMUTABLE_LIST): drv/ImmutableList.drv; ./gencsource.sh $< $@ >$@
 
 CSOURCES += $(IMMUTABLE_LIST)
 
-IMMUTABLE_SET := $(foreach k,$(TYPE_NOBOOL_NOOBJ), $(GEN_SRCDIR)/$(PKG_PATH)/$(PACKAGE_$(k))/Immutable$(k)Set.c)
+IMMUTABLE_SET := $(foreach k,$(TYPE_NOBOOL), $(GEN_SRCDIR)/$(PKG_PATH)/$(PACKAGE_$(k))/Immutable$(k)Set.c)
 $(IMMUTABLE_SET): drv/ImmutableSet.drv; ./gencsource.sh $< $@ >$@
 
 CSOURCES += $(IMMUTABLE_SET)
@@ -455,7 +455,7 @@ CSOURCES += $(ARRAY_INDIRECT_PRIORITY_QUEUES)
 # Static containers
 #
 
-IMMUTABLES := $(foreach k,$(TYPE_NOBOOL_NOOBJ), $(GEN_SRCDIR)/$(PKG_PATH)/$(PACKAGE_$(k))/$(k)Immutables.c)
+IMMUTABLES := $(foreach k,$(TYPE_NOBOOL), $(GEN_SRCDIR)/$(PKG_PATH)/$(PACKAGE_$(k))/$(k)Immutables.c)
 $(IMMUTABLES): drv/Immutables.drv; ./gencsource.sh $< $@ >$@
 
 CSOURCES += $(IMMUTABLES)
@@ -561,10 +561,15 @@ $(COMPARATORS_STATIC): drv/Comparators.drv; ./gencsource.sh $< $@ >$@
 
 CSOURCES += $(COMPARATORS_STATIC)
 
-COLLECTORS := $(foreach k,$(TYPE_NOBOOL_NOOBJ), $(GEN_SRCDIR)/$(PKG_PATH)/$(PACKAGE_$(k))/$(k)Collectors.c)
+COLLECTORS := $(foreach k,$(TYPE_NOBOOL), $(GEN_SRCDIR)/$(PKG_PATH)/$(PACKAGE_$(k))/$(k)Collectors.c)
 $(COLLECTORS): drv/Collectors.drv; ./gencsource.sh $< $@ >$@
 
 CSOURCES += $(COLLECTORS)
+
+MAP_COLLECTORS := $(foreach k,$(TYPE_NOBOOL), $(foreach v,$(TYPE_NOBOOL), $(GEN_SRCDIR)/$(PKG_PATH)/$(PACKAGE_$(k))/$(k)2$(v)Collectors.c))
+$(MAP_COLLECTORS): drv/MapCollectors.drv; ./gencsource.sh $< $@ >$@
+
+CSOURCES += $(MAP_COLLECTORS)
 
 #
 # Fragmented stuff


### PR DESCRIPTION
- immutable set supports all types, including objects
- immutable map keyset and entry set return immutable sets
- support for primitive streams on primitive collections. For ex., both
  ShortCollection and IntCollection will have an intStream method
- support for collecting from primitive streams to sets and lists in
  Collectors.

I still need to figure out best way to support ImmutableMaps and Maps,
I will update this patch once I do.