### PR TITLE
fastutil performance optimizations:

### DIFF
--- a/drv/AVLTreeMap.drv
+++ b/drv/AVLTreeMap.drv
@@ -1329,6 +1329,11 @@ public class AVL_TREE_MAP KEY_VALUE_GENERIC extends ABSTRACT_SORTED_MAP  KEY_VAL
 		return entries;
 	}
 
+	@Override
+	public ObjectSortedSet<MAP.Entry KEY_VALUE_GENERIC> FAST_ENTRYSET() {
+		return ENTRYSET();
+	}
+
 	/** An iterator on the whole range of keys.
 	 *
 	 * <p>This class can iterate in both directions on the keys of a threaded tree. We
@@ -1565,6 +1570,11 @@ public class AVL_TREE_MAP KEY_VALUE_GENERIC extends ABSTRACT_SORTED_MAP  KEY_VAL
 				};
 
 			return entries;
+		}
+
+		@Override
+		public ObjectSortedSet<MAP.Entry KEY_VALUE_GENERIC> FAST_ENTRYSET() {
+			return ENTRYSET();
 		}
 
 		private class KeySet extends ABSTRACT_SORTED_MAP KEY_VALUE_GENERIC.KeySet {

--- a/drv/ArrayMap.drv
+++ b/drv/ArrayMap.drv
@@ -109,7 +109,7 @@ public class ARRAY_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENERIC 
 		if (size > key.length) throw new IllegalArgumentException("The provided size (" + size + ") is larger than or equal to the backing-arrays size (" + key.length + ")");
 	}
 
-	private final class EntrySet extends AbstractObjectSet<MAP.Entry KEY_VALUE_GENERIC> implements FastEntrySet KEY_VALUE_GENERIC {
+	private class EntrySet extends AbstractObjectSet<MAP.Entry KEY_VALUE_GENERIC> implements FastEntrySet KEY_VALUE_GENERIC {
 
 		@Override
 		public ObjectIterator<MAP.Entry KEY_VALUE_GENERIC> iterator() {
@@ -258,6 +258,23 @@ public class ARRAY_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENERIC 
 
 	@Override
 	public FastEntrySet KEY_VALUE_GENERIC ENTRYSET() { return new EntrySet(); }
+
+
+	private final class FastMapEntrySet extends EntrySet {
+
+		@Override
+		public ObjectIterator<MAP.Entry KEY_VALUE_GENERIC> iterator() {
+			return super.fastIterator();
+		}
+
+		@Override
+		public Stream<MAP.Entry KEY_VALUE_GENERIC> stream() {
+			throw new UnsupportedOperationException("Use " + ENTRYSET + "()");
+		}
+	}
+
+	@Override
+	public FastEntrySet KEY_VALUE_GENERIC FAST_ENTRYSET() { return new FastMapEntrySet(); }
 
 	private int findKey(final KEY_TYPE k) {
 		final KEY_TYPE[] key = this.key;

--- a/drv/ImmutableMap.drv
+++ b/drv/ImmutableMap.drv
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.NoSuchElementException;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 
 #if VALUES_PRIMITIVE
 import VALUE_PACKAGE.VALUE_ITERATOR;
@@ -558,7 +559,7 @@ public abstract class IMMUTABLE_MAP KEY_VALUE_GENERIC implements MAP KEY_VALUE_G
             }
         }
 
-        private final class MapEntrySet extends ImmutableObjectSet<MAP.Entry KEY_VALUE_GENERIC> implements FastEntrySet KEY_VALUE_GENERIC {
+        private class MapEntrySet extends ImmutableObjectSet<MAP.Entry KEY_VALUE_GENERIC> implements FastEntrySet KEY_VALUE_GENERIC {
 
             @Override
             public ObjectIterator<MAP.Entry KEY_VALUE_GENERIC> iterator() { return new EntryIterator(); }
@@ -671,6 +672,27 @@ public abstract class IMMUTABLE_MAP KEY_VALUE_GENERIC implements MAP KEY_VALUE_G
         @Override
         public FastEntrySet KEY_VALUE_GENERIC ENTRYSET() {
             return new MapEntrySet();
+        }
+
+        private final class FastMapEntrySet extends MapEntrySet {
+
+            @Override
+            public ObjectIterator<MAP.Entry KEY_VALUE_GENERIC> iterator() { return new FastEntryIterator(); }
+
+            @Override
+            public void forEach(final Consumer<? super MAP.Entry KEY_VALUE_GENERIC> consumer) {
+                super.fastForEach(consumer);
+            }
+
+            @Override
+            public Stream<MAP.Entry KEY_VALUE_GENERIC> stream() {
+                throw new UnsupportedOperationException("Not supported for fast entry set.");
+            }
+        }
+
+        @Override
+        public FastEntrySet KEY_VALUE_GENERIC FAST_ENTRYSET() {
+            return new FastMapEntrySet();
         }
 
         @Override
@@ -868,6 +890,11 @@ public abstract class IMMUTABLE_MAP KEY_VALUE_GENERIC implements MAP KEY_VALUE_G
         }
 
         @Override
+        public FastEntrySet KEY_VALUE_GENERIC FAST_ENTRYSET() {
+            return new MapEntrySet();
+        }
+
+        @Override
         public IMMUTABLE_SET KEY_GENERIC keySet() {
             return new IMMUTABLE_SET.SingletonImmutableSet KEY_GENERIC_DIAMOND(key);
         }
@@ -946,5 +973,8 @@ public abstract class IMMUTABLE_MAP KEY_VALUE_GENERIC implements MAP KEY_VALUE_G
 
     @Override
     public abstract IMMUTABLE_SET KEY_GENERIC keySet();
+
+    @Override
+    public abstract FastEntrySet KEY_VALUE_GENERIC FAST_ENTRYSET();
 }
 

--- a/drv/Map.drv
+++ b/drv/Map.drv
@@ -146,7 +146,18 @@ public interface MAP KEY_VALUE_GENERIC extends FUNCTION KEY_VALUE_GENERIC, Map<K
 	 */
 	ObjectSet<MAP.Entry KEY_VALUE_GENERIC> ENTRYSET();
 
-#if KEYS_PRIMITIVE || VALUES_PRIMITIVE
+	/**
+	 * An entry set that doesn't create new entry objects for iterator. Note that calling
+	 * {@code stream()} on this set is not allowed and will throw an exception if the subclass cannot
+	 * create a stream without creating new entry objects for each entry.
+	 */
+	ObjectSet<MAP.Entry KEY_VALUE_GENERIC> FAST_ENTRYSET();
+
+	@Deprecated
+	default ObjectSet<MAP.Entry KEY_VALUE_GENERIC> DEPRECATED_ENTRYSET() {
+		return ENTRYSET();
+	}
+
 	/** Returns a set view of the mappings contained in this map.
 	 *  <p>Note that this specification strengthens the one given in {@link Map#entrySet()}.
 	 *
@@ -160,20 +171,6 @@ public interface MAP KEY_VALUE_GENERIC extends FUNCTION KEY_VALUE_GENERIC, Map<K
 	default ObjectSet<Map.Entry<KEY_GENERIC_CLASS, VALUE_GENERIC_CLASS>> entrySet() {
 		return (ObjectSet)ENTRYSET();
 	}
-#else
-	/** Returns a set view of the mappings contained in this map.
-	 *  <p>Note that this specification strengthens the one given in {@link Map#entrySet()}.
-	 *
-	 * @return a set view of the mappings contained in this map.
-	 * @see Map#entrySet()
-	 */
-
-	@Override
-	@SuppressWarnings({ "unchecked", "rawtypes" })
-	default ObjectSet<Map.Entry<KEY_GENERIC_CLASS, VALUE_GENERIC_CLASS>> entrySet() {
-		return (ObjectSet)ENTRYSET();
-	}
-#endif
 
 #if KEYS_PRIMITIVE || VALUES_PRIMITIVE
 	/** {@inheritDoc}

--- a/drv/Maps.drv
+++ b/drv/Maps.drv
@@ -109,6 +109,10 @@ public final class MAPS {
 		@Override
 		public ObjectSet<MAP.Entry KEY_VALUE_GENERIC> ENTRYSET() { return ObjectSets.EMPTY_SET; }
 
+		@SuppressWarnings("unchecked")
+		@Override
+		public ObjectSet<MAP.Entry KEY_VALUE_GENERIC> FAST_ENTRYSET() { return ObjectSets.EMPTY_SET; }
+
 		SUPPRESS_WARNINGS_KEY_UNCHECKED
 		@Override
 		public SET KEY_GENERIC keySet() { return SETS.EMPTY_SET; }
@@ -188,13 +192,12 @@ public final class MAPS {
 		@Override
 		public ObjectSet<MAP.Entry KEY_VALUE_GENERIC> ENTRYSET() { if (entries == null) entries = ObjectSets.singleton(new ABSTRACT_MAP.BasicEntry KEY_VALUE_GENERIC_DIAMOND(key, value)); return entries; }
 
-#if KEYS_PRIMITIVE || VALUES_PRIMITIVE
+		@Override
+		public ObjectSet<MAP.Entry KEY_VALUE_GENERIC> FAST_ENTRYSET() { return ENTRYSET(); }
+
 		/** {@inheritDoc}
 		 * @deprecated Please use the corresponding type-specific method instead. */
 		@Deprecated
-#else
-		/** {@inheritDoc} */
-#endif
 		@Override
 		@SuppressWarnings({ "rawtypes", "unchecked" })
 		public ObjectSet<Map.Entry<KEY_GENERIC_CLASS, VALUE_GENERIC_CLASS>> entrySet() { return (ObjectSet)ENTRYSET(); }
@@ -218,7 +221,7 @@ public final class MAPS {
 
 			Map<?,?> m = (Map<?,?>)o;
 			if (m.size() != 1) return false;
-			return m.entrySet().iterator().next().equals(entrySet().iterator().next());
+			return m.entrySet().iterator().next().equals(ENTRYSET().iterator().next());
 		}
 
 		@Override
@@ -291,13 +294,12 @@ public final class MAPS {
 		@Override
 		public ObjectSet<MAP.Entry KEY_VALUE_GENERIC> ENTRYSET() { synchronized(sync) { if (entries == null) entries = ObjectSets.synchronize(map.ENTRYSET(), sync); return entries; } }
 
-#if KEYS_PRIMITIVE || VALUES_PRIMITIVE
+		@Override
+		public ObjectSet<MAP.Entry KEY_VALUE_GENERIC> FAST_ENTRYSET() { synchronized(sync) { return ObjectSets.synchronize(map.FAST_ENTRYSET(), sync); } }
+
 		/** {@inheritDoc}
 		 * @deprecated Please use the corresponding type-specific method instead. */
 		@Deprecated
-#else
-		/** {@inheritDoc} */
-#endif
 		@Override
 		@SuppressWarnings({ "unchecked", "rawtypes" })
 		public ObjectSet<Map.Entry<KEY_GENERIC_CLASS, VALUE_GENERIC_CLASS>> entrySet() { return (ObjectSet)ENTRYSET(); }
@@ -498,13 +500,12 @@ public final class MAPS {
 		@Override
 		public ObjectSet<MAP.Entry KEY_VALUE_GENERIC> ENTRYSET() { if (entries == null) entries = ObjectSets.unmodifiable(map.ENTRYSET()); return entries; }
 
-#if KEYS_PRIMITIVE || VALUES_PRIMITIVE
+		@Override
+		public ObjectSet<MAP.Entry KEY_VALUE_GENERIC> FAST_ENTRYSET() { return ObjectSets.unmodifiable(map.FAST_ENTRYSET()); }
+
 		/** {@inheritDoc}
 		 * @deprecated Please use the corresponding type-specific method instead. */
 		@Deprecated
-#else
-		/** {@inheritDoc} */
-#endif
 		@Override
 		@SuppressWarnings({ "unchecked", "rawtypes" })
 		public ObjectSet<Map.Entry<KEY_GENERIC_CLASS, VALUE_GENERIC_CLASS>> entrySet() { return (ObjectSet)ENTRYSET(); }

--- a/drv/OpenHashMap.drv
+++ b/drv/OpenHashMap.drv
@@ -28,6 +28,7 @@ import java.util.function.Consumer;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.stream.Stream;
 
 import VALUE_PACKAGE.VALUE_COLLECTION;
 import VALUE_PACKAGE.VALUE_ABSTRACT_COLLECTION;
@@ -1852,7 +1853,7 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 #endif
 
 #ifdef Linked
-	private final class MapEntrySet extends AbstractObjectSortedSet<MAP.Entry KEY_VALUE_GENERIC> implements FastSortedEntrySet KEY_VALUE_GENERIC {
+	private class MapEntrySet extends AbstractObjectSortedSet<MAP.Entry KEY_VALUE_GENERIC> implements FastSortedEntrySet KEY_VALUE_GENERIC {
 
 		@Override
 		public ObjectBidirectionalIterator<MAP.Entry KEY_VALUE_GENERIC> iterator() { return new EntryIterator(); }
@@ -1882,7 +1883,7 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 		}
 
 #else
-	private final class MapEntrySet extends AbstractObjectSet<MAP.Entry KEY_VALUE_GENERIC> implements FastEntrySet KEY_VALUE_GENERIC {
+	private class MapEntrySet extends AbstractObjectSet<MAP.Entry KEY_VALUE_GENERIC> implements FastEntrySet KEY_VALUE_GENERIC {
 
 		@Override
 		public ObjectIterator<MAP.Entry KEY_VALUE_GENERIC> iterator() { return new EntryIterator(); }
@@ -2095,7 +2096,6 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 #endif
 	}
 
-
 #ifdef Linked
 	@Override
 	public FastSortedEntrySet KEY_VALUE_GENERIC ENTRYSET() {
@@ -2106,6 +2106,43 @@ public class OPEN_HASH_MAP KEY_VALUE_GENERIC extends ABSTRACT_MAP KEY_VALUE_GENE
 		if (entries == null) entries = new MapEntrySet();
 #endif
 		return entries;
+	}
+
+	private final class FastMapEntrySet extends MapEntrySet {
+
+#ifdef Linked
+		@Override
+		public ObjectBidirectionalIterator<MAP.Entry KEY_VALUE_GENERIC> iterator() { return new FastEntryIterator(); }
+
+		@Override
+		public ObjectListIterator<MAP.Entry KEY_VALUE_GENERIC> iterator(final MAP.Entry KEY_VALUE_GENERIC from) {
+			return new FastEntryIterator(from.ENTRY_GET_KEY());
+		}
+#else
+
+		@Override
+		public ObjectIterator<MAP.Entry KEY_VALUE_GENERIC> iterator() { return new FastEntryIterator(); }
+#endif
+
+		@Override
+		public void forEach(final Consumer<? super MAP.Entry KEY_VALUE_GENERIC> consumer) {
+			super.fastForEach(consumer);
+		}
+
+		@Override
+		public Stream<MAP.Entry KEY_VALUE_GENERIC> stream() {
+			throw new UnsupportedOperationException("Not supported for fast entry set.");
+		}
+	}
+
+#ifdef Linked
+@Override
+	public FastSortedEntrySet KEY_VALUE_GENERIC FAST_ENTRYSET() {
+#else
+	@Override
+	public FastEntrySet KEY_VALUE_GENERIC FAST_ENTRYSET() {
+#endif
+		return new FastMapEntrySet();
 	}
 
 	/** An iterator on keys.

--- a/drv/RBTreeMap.drv
+++ b/drv/RBTreeMap.drv
@@ -1255,6 +1255,11 @@ public class RB_TREE_MAP KEY_VALUE_GENERIC extends ABSTRACT_SORTED_MAP KEY_VALUE
 		return entries;
 	}
 
+	@Override
+	public ObjectSortedSet<MAP.Entry KEY_VALUE_GENERIC> FAST_ENTRYSET() {
+		return ENTRYSET();
+	}
+
 	/** An iterator on the whole range of keys.
 	 *
 	 * <p>This class can iterate in both directions on the keys of a threaded tree. We
@@ -1500,6 +1505,11 @@ public class RB_TREE_MAP KEY_VALUE_GENERIC extends ABSTRACT_SORTED_MAP KEY_VALUE
 				};
 
 			return entries;
+		}
+
+		@Override
+		public ObjectSortedSet<MAP.Entry KEY_VALUE_GENERIC> FAST_ENTRYSET() {
+			return ENTRYSET();
 		}
 
 		private class KeySet extends ABSTRACT_SORTED_MAP KEY_VALUE_GENERIC.KeySet {

--- a/drv/SortedMap.drv
+++ b/drv/SortedMap.drv
@@ -159,7 +159,6 @@ public interface SORTED_MAP KEY_VALUE_GENERIC extends MAP KEY_VALUE_GENERIC, Sor
 		ObjectBidirectionalIterator<MAP.Entry KEY_VALUE_GENERIC> fastIterator(MAP.Entry KEY_VALUE_GENERIC from);
 	}
 
-#if KEYS_PRIMITIVE || VALUES_PRIMITIVE
 	/** Returns a sorted-set view of the mappings contained in this map.
 	 *  <p>Note that this specification strengthens the one given in the
 	 *  corresponding type-specific unsorted map.
@@ -175,21 +174,6 @@ public interface SORTED_MAP KEY_VALUE_GENERIC extends MAP KEY_VALUE_GENERIC, Sor
 	default ObjectSortedSet<Map.Entry<KEY_GENERIC_CLASS, VALUE_GENERIC_CLASS>> entrySet() {
 		return (ObjectSortedSet)ENTRYSET();
 	}
-#else
-	/** Returns a sorted-set view of the mappings contained in this map.
-	 *  <p>Note that this specification strengthens the one given in the
-	 *  corresponding type-specific unsorted map.
-	 *
-	 * @return a sorted-set view of the mappings contained in this map.
-	 * @see Map#entrySet()
-	 */
-
-	@SuppressWarnings({ "unchecked", "rawtypes" })
-	@Override
-	default ObjectSortedSet<Map.Entry<KEY_GENERIC_CLASS, VALUE_GENERIC_CLASS>> entrySet() {
-		return (ObjectSortedSet)ENTRYSET();
-	}
-#endif
 
 	/** Returns a type-specific sorted-set view of the mappings contained in this map.
 	 * <p>Note that this specification strengthens the one given in the
@@ -201,6 +185,14 @@ public interface SORTED_MAP KEY_VALUE_GENERIC extends MAP KEY_VALUE_GENERIC, Sor
 
 	@Override
 	ObjectSortedSet<MAP.Entry KEY_VALUE_GENERIC> ENTRYSET();
+
+	/**
+	 * An entry set that doesn't create new entry objects for iterator. Note that calling
+	 * {@code stream()} on this set is not allowed and will throw an exception if the subclass cannot
+	 * create a stream without creating new entry objects for each entry.
+	 */
+	@Override
+	ObjectSortedSet<MAP.Entry KEY_VALUE_GENERIC> FAST_ENTRYSET();
 
 	/** Returns a type-specific sorted-set view of the keys contained in this map.
 	 *  <p>Note that this specification strengthens the one given in the

--- a/drv/SortedMaps.drv
+++ b/drv/SortedMaps.drv
@@ -88,13 +88,13 @@ public final class SORTED_MAPS {
 		@Override
 		public ObjectSortedSet<MAP.Entry KEY_VALUE_GENERIC> ENTRYSET() { return ObjectSortedSets.EMPTY_SET; }
 
-#if KEYS_PRIMITIVE || VALUES_PRIMITIVE
+		@SuppressWarnings("unchecked")
+		@Override
+		public ObjectSortedSet<MAP.Entry KEY_VALUE_GENERIC> FAST_ENTRYSET() { return ObjectSortedSets.EMPTY_SET; }
+
 		/** {@inheritDoc}
 		 * @deprecated Please use the corresponding type-specific method instead. */
 		@Deprecated
-#else
-		/** {@inheritDoc} */
-#endif
 		@Override
 		@SuppressWarnings("unchecked")
 		public ObjectSortedSet<Map.Entry<KEY_GENERIC_CLASS, VALUE_GENERIC_CLASS>> entrySet() { return ObjectSortedSets.EMPTY_SET; }
@@ -206,13 +206,13 @@ public final class SORTED_MAPS {
 		@Override
 		public ObjectSortedSet<MAP.Entry KEY_VALUE_GENERIC> ENTRYSET() { if (entries == null) entries = ObjectSortedSets.singleton(new ABSTRACT_MAP.BasicEntry KEY_VALUE_GENERIC_DIAMOND(key, value), entryComparator(comparator)); return (ObjectSortedSet<MAP.Entry KEY_VALUE_GENERIC>)entries; }
 
-#if KEYS_PRIMITIVE || VALUES_PRIMITIVE
+		SUPPRESS_WARNINGS_KEY_UNCHECKED
+		@Override
+		public ObjectSortedSet<MAP.Entry KEY_VALUE_GENERIC> FAST_ENTRYSET() { return ENTRYSET(); }
+
 		/** {@inheritDoc}
 		 * @deprecated Please use the corresponding type-specific method instead. */
 		@Deprecated
-#else
-		/** {@inheritDoc} */
-#endif
 		@Override
 		@SuppressWarnings({ "rawtypes", "unchecked" })
 		public ObjectSortedSet<Map.Entry<KEY_GENERIC_CLASS, VALUE_GENERIC_CLASS>> entrySet() { return (ObjectSortedSet)ENTRYSET(); }
@@ -350,13 +350,12 @@ public final class SORTED_MAPS {
 		@Override
 		public ObjectSortedSet<MAP.Entry KEY_VALUE_GENERIC> ENTRYSET() { if (entries == null) entries = ObjectSortedSets.synchronize(sortedMap.ENTRYSET(), sync); return (ObjectSortedSet<MAP.Entry KEY_VALUE_GENERIC>)entries; }
 
-#if KEYS_PRIMITIVE || VALUES_PRIMITIVE
+		@Override
+		public ObjectSortedSet<MAP.Entry KEY_VALUE_GENERIC> FAST_ENTRYSET() { return ObjectSortedSets.synchronize(sortedMap.FAST_ENTRYSET(), sync); }
+
 		/** {@inheritDoc}
 		 * @deprecated Please use the corresponding type-specific method instead. */
 		@Deprecated
-#else
-		/** {@inheritDoc} */
-#endif
 		@Override
 		@SuppressWarnings({ "rawtypes", "unchecked" })
 		public ObjectSortedSet<Map.Entry<KEY_GENERIC_CLASS, VALUE_GENERIC_CLASS>> entrySet() { return (ObjectSortedSet)ENTRYSET(); }
@@ -454,13 +453,12 @@ public final class SORTED_MAPS {
 		@Override
 		public ObjectSortedSet<MAP.Entry KEY_VALUE_GENERIC> ENTRYSET() { if (entries == null) entries = ObjectSortedSets.unmodifiable(sortedMap.ENTRYSET()); return (ObjectSortedSet<MAP.Entry KEY_VALUE_GENERIC>)entries; }
 
-#if KEYS_PRIMITIVE || VALUES_PRIMITIVE
+		@Override
+		public ObjectSortedSet<MAP.Entry KEY_VALUE_GENERIC> FAST_ENTRYSET() { return ObjectSortedSets.unmodifiable(sortedMap.FAST_ENTRYSET()); }
+
 		/** {@inheritDoc}
 		 * @deprecated Please use the corresponding type-specific method instead. */
 		@Deprecated
-#else
-		/** {@inheritDoc} */
-#endif
 		@Override
 		@SuppressWarnings({ "rawtypes", "unchecked" })
 		public ObjectSortedSet<Map.Entry<KEY_GENERIC_CLASS, VALUE_GENERIC_CLASS>> entrySet() { return (ObjectSortedSet)ENTRYSET(); }

--- a/gencsource.sh
+++ b/gencsource.sh
@@ -570,7 +570,9 @@ fi)\
 "/* Methods (keys/values) */\n"\
 \
 \
-"#define ENTRYSET ${TYPE_LC[$k]}2${TYPE_CAP[$v]}EntrySet\n"\
+"#define DEPRECATED_ENTRYSET ${TYPE_LC[$k]}2${TYPE_CAP[$v]}EntrySet\n"\
+"#define ENTRYSET slowEntrySet\n"\
+"#define FAST_ENTRYSET fastEntrySet\n"\
 \
 \
 "/* Methods that have special names depending on keys (but the special names depend on values) */\n"\

--- a/makefile
+++ b/makefile
@@ -64,6 +64,9 @@ explain:
 	@echo "will compile behavioral and speed tests into the classes.\n"
 	@echo "If you set the make variable ASSERTS (e.g., make sources ASSERTS=1),"
 	@echo "you will compile assertions into the classes.\n"
+	@echo "If you set the make variable FASTEST (e.g., make sources FASTEST=1),"
+	@echo "you will only compile classes where there is a clear performance "
+	@echo "benefit.\n"
 	@echo "If you set the make variable NO_SMALL_TYPES (e.g.,"
 	@echo "make sources NO_SMALL_TYPES=1), you will only generate classes "
 	@echo "involving ints, longs and doubles (and some byte utility)."
@@ -151,10 +154,12 @@ $(HASHES): drv/Hash.drv; ./gencsource.sh $< $@ >$@
 
 CSOURCES += $(HASHES)
 
+ifneq ($(FASTEST),1)
 SORTED_SETS := $(foreach k,$(TYPE_NOBOOL), $(GEN_SRCDIR)/$(PKG_PATH)/$(PACKAGE_$(k))/$(k)SortedSet.c)
 $(SORTED_SETS): drv/SortedSet.drv; ./gencsource.sh $< $@ >$@
 
 CSOURCES += $(SORTED_SETS)
+endif
 
 FUNCTIONS := $(foreach k,$(TYPE_NOBOOL), $(foreach v,$(TYPE), $(GEN_SRCDIR)/$(PKG_PATH)/$(PACKAGE_$(k))/$(k)2$(v)Function.c))
 $(FUNCTIONS): drv/Function.drv; ./gencsource.sh $< $@ >$@
@@ -166,10 +171,12 @@ $(MAPS): drv/Map.drv; ./gencsource.sh $< $@ >$@
 
 CSOURCES += $(MAPS)
 
+ifneq ($(FASTEST),1)
 SORTED_MAPS := $(foreach k,$(TYPE_NOBOOL), $(foreach v,$(TYPE), $(GEN_SRCDIR)/$(PKG_PATH)/$(PACKAGE_$(k))/$(k)2$(v)SortedMap.c))
 $(SORTED_MAPS): drv/SortedMap.drv; ./gencsource.sh $< $@ >$@
 
 CSOURCES += $(SORTED_MAPS)
+endif
 
 LISTS := $(foreach k,$(TYPE), $(GEN_SRCDIR)/$(PKG_PATH)/$(PACKAGE_$(k))/$(k)List.c)
 $(LISTS): drv/List.drv; ./gencsource.sh $< $@ >$@
@@ -256,10 +263,13 @@ $(ABSTRACT_SETS): drv/AbstractSet.drv; ./gencsource.sh $< $@ >$@
 
 CSOURCES += $(ABSTRACT_SETS)
 
+
+ifneq ($(FASTEST),1)
 ABSTRACT_SORTED_SETS := $(foreach k,$(TYPE_NOBOOL), $(GEN_SRCDIR)/$(PKG_PATH)/$(PACKAGE_$(k))/Abstract$(k)SortedSet.c)
 $(ABSTRACT_SORTED_SETS): drv/AbstractSortedSet.drv; ./gencsource.sh $< $@ >$@
 
 CSOURCES += $(ABSTRACT_SORTED_SETS)
+endif
 
 ABSTRACT_FUNCTIONS := $(foreach k,$(TYPE_NOBOOL), $(foreach v,$(TYPE), $(GEN_SRCDIR)/$(PKG_PATH)/$(PACKAGE_$(k))/Abstract$(k)2$(v)Function.c))
 $(ABSTRACT_FUNCTIONS): drv/AbstractFunction.drv; ./gencsource.sh $< $@ >$@
@@ -271,10 +281,12 @@ $(ABSTRACT_MAPS): drv/AbstractMap.drv; ./gencsource.sh $< $@ >$@
 
 CSOURCES += $(ABSTRACT_MAPS)
 
+ifneq ($(FASTEST),1)
 ABSTRACT_SORTED_MAPS := $(foreach k,$(TYPE_NOBOOL), $(foreach v,$(TYPE), $(GEN_SRCDIR)/$(PKG_PATH)/$(PACKAGE_$(k))/Abstract$(k)2$(v)SortedMap.c))
 $(ABSTRACT_SORTED_MAPS): drv/AbstractSortedMap.drv; ./gencsource.sh $< $@ >$@
 
 CSOURCES += $(ABSTRACT_SORTED_MAPS)
+endif
 
 ABSTRACT_LISTS := $(foreach k,$(TYPE), $(GEN_SRCDIR)/$(PKG_PATH)/$(PACKAGE_$(k))/Abstract$(k)List.c)
 $(ABSTRACT_LISTS): drv/AbstractList.drv; ./gencsource.sh $< $@ >$@
@@ -335,75 +347,95 @@ $(OPEN_HASH_BIG_SETS): drv/OpenHashBigSet.drv; ./gencsource.sh $< $@ >$@
 
 CSOURCES += $(OPEN_HASH_BIG_SETS)
 
+ifneq ($(FASTEST),1)
 LINKED_OPEN_HASH_SETS := $(foreach k,$(TYPE_NOBOOL), $(GEN_SRCDIR)/$(PKG_PATH)/$(PACKAGE_$(k))/$(k)LinkedOpenHashSet.c)
 $(LINKED_OPEN_HASH_SETS): drv/LinkedOpenHashSet.drv; ./gencsource.sh $< $@ >$@
 
 CSOURCES += $(LINKED_OPEN_HASH_SETS)
+endif
 
 OPEN_CUSTOM_HASH_SETS := $(foreach k,$(TYPE_NOBOOL_NOREF), $(GEN_SRCDIR)/$(PKG_PATH)/$(PACKAGE_$(k))/$(k)OpenCustomHashSet.c)
 $(OPEN_CUSTOM_HASH_SETS): drv/OpenCustomHashSet.drv; ./gencsource.sh $< $@ >$@
 
 CSOURCES += $(OPEN_CUSTOM_HASH_SETS)
 
+ifneq ($(FASTEST),1)
 LINKED_OPEN_CUSTOM_HASH_SETS := $(foreach k,$(TYPE_NOBOOL_NOREF), $(GEN_SRCDIR)/$(PKG_PATH)/$(PACKAGE_$(k))/$(k)LinkedOpenCustomHashSet.c)
 $(LINKED_OPEN_CUSTOM_HASH_SETS): drv/LinkedOpenCustomHashSet.drv; ./gencsource.sh $< $@ >$@
 
 CSOURCES += $(LINKED_OPEN_CUSTOM_HASH_SETS)
+endif
 
+ifneq ($(FASTEST),1)
 ARRAY_SETS := $(foreach k,$(TYPE), $(GEN_SRCDIR)/$(PKG_PATH)/$(PACKAGE_$(k))/$(k)ArraySet.c)
 $(ARRAY_SETS): drv/ArraySet.drv; ./gencsource.sh $< $@ >$@
 
 CSOURCES += $(ARRAY_SETS)
+endif
 
+ifneq ($(FASTEST),1)
 AVL_TREE_SETS := $(foreach k,$(TYPE_NOBOOL_NOREF), $(GEN_SRCDIR)/$(PKG_PATH)/$(PACKAGE_$(k))/$(k)AVLTreeSet.c)
 $(AVL_TREE_SETS): drv/AVLTreeSet.drv; ./gencsource.sh $< $@ >$@
 
 CSOURCES += $(AVL_TREE_SETS)
+endif
 
+ifneq ($(FASTEST),1)
 RB_TREE_SETS := $(foreach k,$(TYPE_NOBOOL_NOREF), $(GEN_SRCDIR)/$(PKG_PATH)/$(PACKAGE_$(k))/$(k)RBTreeSet.c)
 $(RB_TREE_SETS): drv/RBTreeSet.drv; ./gencsource.sh $< $@ >$@
 
 CSOURCES += $(RB_TREE_SETS)
+endif
 
 OPEN_HASH_MAPS := $(foreach k,$(TYPE_NOBOOL), $(foreach v,$(TYPE), $(GEN_SRCDIR)/$(PKG_PATH)/$(PACKAGE_$(k))/$(k)2$(v)OpenHashMap.c))
 $(OPEN_HASH_MAPS): drv/OpenHashMap.drv; ./gencsource.sh $< $@ >$@
 
 CSOURCES += $(OPEN_HASH_MAPS)
 
+ifneq ($(FASTEST),1)
 LINKED_OPEN_HASH_MAPS := $(foreach k,$(TYPE_NOBOOL), $(foreach v,$(TYPE), $(GEN_SRCDIR)/$(PKG_PATH)/$(PACKAGE_$(k))/$(k)2$(v)LinkedOpenHashMap.c))
 $(LINKED_OPEN_HASH_MAPS): drv/LinkedOpenHashMap.drv; ./gencsource.sh $< $@ >$@
 
 CSOURCES += $(LINKED_OPEN_HASH_MAPS)
+endif
 
 OPEN_CUSTOM_HASH_MAPS := $(foreach k,$(TYPE_NOBOOL), $(foreach v,$(TYPE), $(GEN_SRCDIR)/$(PKG_PATH)/$(PACKAGE_$(k))/$(k)2$(v)OpenCustomHashMap.c))
 $(OPEN_CUSTOM_HASH_MAPS): drv/OpenCustomHashMap.drv; ./gencsource.sh $< $@ >$@
 
 CSOURCES += $(OPEN_CUSTOM_HASH_MAPS)
 
+ifneq ($(FASTEST),1)
 LINKED_OPEN_CUSTOM_HASH_MAPS := $(foreach v,$(TYPE), $(GEN_SRCDIR)/$(PKG_PATH)/objects/Object2$(v)LinkedOpenCustomHashMap.c)
 $(LINKED_OPEN_CUSTOM_HASH_MAPS): drv/LinkedOpenCustomHashMap.drv; ./gencsource.sh $< $@ >$@
 
 CSOURCES += $(LINKED_OPEN_CUSTOM_HASH_MAPS)
+endif
 
 #STRIPED_OPEN_HASH_MAPS := $(foreach k,$(TYPE_NOBOOL), $(foreach v,$(TYPE), $(GEN_SRCDIR)/$(PKG_PATH)/$(PACKAGE_$(k))/Striped$(k)2$(v)OpenHashMap.c))
 #$(STRIPED_OPEN_HASH_MAPS): drv/StripedOpenHashMap.drv; ./gencsource.sh $< $@ >$@
 
 #CSOURCES += $(STRIPED_OPEN_HASH_MAPS)
 
+ifneq ($(FASTEST),1)
 ARRAY_MAPS := $(foreach k,$(TYPE_NOBOOL), $(foreach v,$(TYPE), $(GEN_SRCDIR)/$(PKG_PATH)/$(PACKAGE_$(k))/$(k)2$(v)ArrayMap.c))
 $(ARRAY_MAPS): drv/ArrayMap.drv; ./gencsource.sh $< $@ >$@
 
 CSOURCES += $(ARRAY_MAPS)
+endif
 
+ifneq ($(FASTEST),1)
 AVL_TREE_MAPS := $(foreach k,$(TYPE_NOBOOL_NOREF), $(foreach v,$(TYPE), $(GEN_SRCDIR)/$(PKG_PATH)/$(PACKAGE_$(k))/$(k)2$(v)AVLTreeMap.c))
 $(AVL_TREE_MAPS): drv/AVLTreeMap.drv; ./gencsource.sh $< $@ >$@
 
 CSOURCES += $(AVL_TREE_MAPS)
+endif
 
+ifneq ($(FASTEST),1)
 RB_TREE_MAPS := $(foreach k,$(TYPE_NOBOOL_NOREF), $(foreach v,$(TYPE), $(GEN_SRCDIR)/$(PKG_PATH)/$(PACKAGE_$(k))/$(k)2$(v)RBTreeMap.c))
 $(RB_TREE_MAPS): drv/RBTreeMap.drv; ./gencsource.sh $< $@ >$@
 
 CSOURCES += $(RB_TREE_MAPS)
+endif
 
 ARRAY_LISTS := $(foreach k,$(TYPE), $(GEN_SRCDIR)/$(PKG_PATH)/$(PACKAGE_$(k))/$(k)ArrayList.c)
 $(ARRAY_LISTS): drv/ArrayList.drv; ./gencsource.sh $< $@ >$@
@@ -484,10 +516,12 @@ $(SETS_STATIC): drv/Sets.drv; ./gencsource.sh $< $@ >$@
 CSOURCES += $(SETS_STATIC)
 
 
+ifneq ($(FASTEST),1)
 SORTED_SETS_STATIC := $(foreach k,$(TYPE_NOBOOL), $(GEN_SRCDIR)/$(PKG_PATH)/$(PACKAGE_$(k))/$(k)SortedSets.c)
 $(SORTED_SETS_STATIC): drv/SortedSets.drv; ./gencsource.sh $< $@ >$@
 
 CSOURCES += $(SORTED_SETS_STATIC)
+endif
 
 
 LISTS_STATIC := $(foreach k,$(TYPE), $(GEN_SRCDIR)/$(PKG_PATH)/$(PACKAGE_$(k))/$(k)Lists.c)
@@ -550,10 +584,12 @@ $(MAPS_STATIC): drv/Maps.drv; ./gencsource.sh $< $@ >$@
 CSOURCES += $(MAPS_STATIC)
 
 
+ifneq ($(FASTEST),1)
 SORTED_MAPS_STATIC := $(foreach k,$(TYPE_NOBOOL), $(foreach v,$(TYPE), $(GEN_SRCDIR)/$(PKG_PATH)/$(PACKAGE_$(k))/$(k)2$(v)SortedMaps.c))
 $(SORTED_MAPS_STATIC): drv/SortedMaps.drv; ./gencsource.sh $< $@ >$@
 
 CSOURCES += $(SORTED_MAPS_STATIC)
+endif
 
 
 COMPARATORS_STATIC := $(foreach k,$(TYPE_NOBOOL_NOREF), $(GEN_SRCDIR)/$(PKG_PATH)/$(PACKAGE_$(k))/$(k)Comparators.c)


### PR DESCRIPTION

    - deprecate old type2typeEntrySet method on maps and instead add
      slowEntrySet (the new ENTRYSET in drv files) and fastEntrySet.

    - add option to makefile that when set, doesn't bring in collections that
      are generally slow: sorted sets (avl + rb), sorted maps (avl + rb),
      sorted sets + maps static classes, array sets and maps, linked sets and maps.
      This reduces fastutil jar size (when makefile option is set) from
      21MB -> 11MB.
