### PR TITLE
Minor perf optimization

### DIFF
--- a/drv/AbstractCollection.drv
+++ b/drv/AbstractCollection.drv
@@ -164,20 +164,17 @@ public abstract class ABSTRACT_COLLECTION KEY_GENERIC extends AbstractCollection
 
 	@Override
 	public boolean addAll(final Collection<? extends KEY_GENERIC_CLASS> c) {
+		boolean modified = false;
 		if (c instanceof COLLECTION){
-			return addAll((COLLECTION) c);
-		} else {
-			return super.addAll(c);
-		}
-	}
+			COLLECTION col = (COLLECTION) c;
 
-	@Override
-	public boolean containsAll(final Collection<?> c) {
-		if (c instanceof COLLECTION) {
-			return containsAll((COLLECTION) c);
+			for (final KEY_ITERATOR i = col.iterator(); i.hasNext();)
+				if (add(i.NEXT_KEY())) modified = true;
 		} else {
-			return super.containsAll(c);
+			for (KEY_GENERIC_CLASS e : c)
+				if (add(e)) modified = true;
 		}
+		return modified;
 	}
 
 	@Override

--- a/drv/ImmutableSet.drv
+++ b/drv/ImmutableSet.drv
@@ -298,6 +298,19 @@ public abstract class IMMUTABLE_SET KEY_GENERIC extends ABSTRACT_SET KEY_GENERIC
         }
 
         @Override
+        public boolean containsAll(final Collection<?> c) {
+            if (c instanceof COLLECTION) {
+                COLLECTION col = (COLLECTION) c;
+                for (final KEY_ITERATOR i = col.iterator(); i.hasNext();)
+                    if (!contains(i.NEXT_KEY())) return false;
+            } else {
+                for (Object e : c)
+                    if (!contains(e)) return false;
+            }
+            return true;
+        }
+
+        @Override
         public KEY_ITERATOR KEY_GENERIC iterator() {
             if (table == null) {
                 return ITERATORS.EMPTY_ITERATOR;


### PR DESCRIPTION
Inline addAll and containsAll in Collection.drv when argument is
a java.util.Collection. Also, AbstractSet.equals(..) calls appropriate
containsAll depending on other set type. This makes it more likely
that containsAll is inlined and shows some performance gains.